### PR TITLE
feat: cache system hardening

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,5 +27,6 @@ module.exports = {
       },
     ],
     'security/detect-non-literal-fs-filename': 0,
+    '@typescript-eslint/unbound-method': 0,
   },
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -2,6 +2,8 @@ jest.mock('simple-git', () => {
   const mockGit = {
     clone: jest.fn(),
     branch: jest.fn(),
+    checkout: jest.fn(),
+    fetch: jest.fn(),
   };
 
   return jest.fn(() => mockGit);

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,6 +1,7 @@
 jest.mock('simple-git', () => {
   const mockGit = {
     clone: jest.fn(),
+    branch: jest.fn(),
   };
 
   return jest.fn(() => mockGit);

--- a/src/handlers/componentInstall.ts
+++ b/src/handlers/componentInstall.ts
@@ -9,6 +9,7 @@ import getGitRepoNameFromUrl from '../util/getGitRepoNameFromUrl';
 import getEmulsifyConfig from '../util/project/getEmulsifyConfig';
 import getJsonFromCachedFile from '../util/cache/getJsonFromCachedFile';
 import installComponentFromCache from '../util/project/installComponentFromCache';
+import cloneIntoCache from '../util/cache/cloneIntoCache';
 
 /**
  * Handler for the `component install` command.
@@ -38,6 +39,18 @@ export default async function componentInstall(name: string): Promise<void> {
     return log(
       'error',
       `The system specified in your project configuration is not valid. Please make sure your ${EMULSIFY_PROJECT_CONFIG_FILE} file contains a system.repository value that is a valid git url`,
+      EXIT_ERROR
+    );
+  }
+
+  // Make sure the given system is installed and has the correct branch/commit/tag checked out.
+  try {
+    await cloneIntoCache('systems', [systemName])(emulsifyConfig.system);
+  } catch (e) {
+    console.log(e);
+    return log(
+      'error',
+      'The system specified in your project configuration is not clone-able, or has an invalid checkout value.',
       EXIT_ERROR
     );
   }

--- a/src/handlers/componentInstall.ts
+++ b/src/handlers/componentInstall.ts
@@ -47,7 +47,6 @@ export default async function componentInstall(name: string): Promise<void> {
   try {
     await cloneIntoCache('systems', [systemName])(emulsifyConfig.system);
   } catch (e) {
-    console.log(e);
     return log(
       'error',
       'The system specified in your project configuration is not clone-able, or has an invalid checkout value.',

--- a/src/handlers/componentList.ts
+++ b/src/handlers/componentList.ts
@@ -8,6 +8,7 @@ import type { EmulsifySystem } from '@emulsify-cli/config';
 import getGitRepoNameFromUrl from '../util/getGitRepoNameFromUrl';
 import getEmulsifyConfig from '../util/project/getEmulsifyConfig';
 import getJsonFromCachedFile from '../util/cache/getJsonFromCachedFile';
+import cloneIntoCache from '../util/cache/cloneIntoCache';
 
 /**
  * Handler for the `component list` command.
@@ -37,6 +38,18 @@ export default async function componentList(): Promise<void> {
     return log(
       'error',
       `The system specified in your project configuration is not valid. Please make sure your ${EMULSIFY_PROJECT_CONFIG_FILE} file contains a system.repository value that is a valid git url`,
+      EXIT_ERROR
+    );
+  }
+
+  // Make sure the given system is installed and has the correct branch/commit/tag checked out.
+  try {
+    await cloneIntoCache('systems', [systemName])(emulsifyConfig.system);
+  } catch (e) {
+    console.log(e);
+    return log(
+      'error',
+      'The system specified in your project configuration is not clone-able, or has an invalid checkout value.',
       EXIT_ERROR
     );
   }

--- a/src/handlers/systemInstall.ts
+++ b/src/handlers/systemInstall.ts
@@ -8,6 +8,7 @@ import log from '../lib/log';
 import getAvailableSystems from '../util/system/getAvailableSystems';
 import getGitRepoNameFromUrl from '../util/getGitRepoNameFromUrl';
 import cloneIntoCache from '../util/cache/cloneIntoCache';
+import getCachedItemCheckout from '../util/cache/getCachedItemCheckout';
 import installComponentFromCache from '../util/project/installComponentFromCache';
 import installGeneralAssetsFromCache from '../util/project/installGeneralAssetsFromCache';
 import getJsonFromCachedFile from '../util/cache/getJsonFromCachedFile';
@@ -63,7 +64,7 @@ export async function getSystemRepoInfo(
 export default async function systemInstall(
   name: string | void,
   options: InstallSystemHandlerOptions
-) {
+): Promise<void> {
   // @TODO: extract some of this into a common util.
   // Attempt to load emulsify config. If none is found, this is not an Emulsify project.
   const projectConfig = await getEmulsifyConfig();
@@ -141,10 +142,17 @@ export default async function systemInstall(
 
   // Update emulsify project config.
   try {
+    //  If no checkout was passed along, and the default checkout was used, fetch
+    // it using simple-git's branch script.
+    let checkout = repo.checkout;
+    if (!checkout) {
+      checkout = await getCachedItemCheckout('systems', [repo.name]);
+    }
+
     await setEmulsifyConfig({
       system: {
         repository: repo.repository,
-        checkout: repo.checkout as string | undefined,
+        checkout,
       },
       // @TODO: Because we don't yet support referenced variants, for now we only
       // pass in the platform name.
@@ -174,7 +182,9 @@ export default async function systemInstall(
   } catch (e) {
     return log(
       'error',
-      `Unable to install system assets and/or required components: ${e}`,
+      `Unable to install system assets and/or required components: ${R.toString(
+        e
+      )}`,
       EXIT_ERROR
     );
   }

--- a/src/handlers/systemInstall.ts
+++ b/src/handlers/systemInstall.ts
@@ -142,8 +142,8 @@ export default async function systemInstall(
 
   // Update emulsify project config.
   try {
-    //  If no checkout was passed along, and the default checkout was used, fetch
-    // it using simple-git's branch script.
+    // If no checkout was passed along, and the default checkout was used, fetch it
+    // it can be stored in the project config.
     let checkout = repo.checkout;
     if (!checkout) {
       checkout = await getCachedItemCheckout('systems', [repo.name]);

--- a/src/schemas/emulsifyProjectConfig.json
+++ b/src/schemas/emulsifyProjectConfig.json
@@ -42,7 +42,7 @@
         }
       },
       "additionalProperties": false,
-      "required": ["repository"]
+      "required": ["repository", "checkout"]
     },
     "variant": {
       "type": "object",

--- a/src/types/_emulsifyProjectConfig.d.ts
+++ b/src/types/_emulsifyProjectConfig.d.ts
@@ -35,7 +35,7 @@ export interface EmulsifyProjectConfiguration {
     /**
      * Commit, branch, or tag of the system this project is utilizing
      */
-    checkout?: string;
+    checkout: string;
   };
   /**
    * Contains information about the Emulsify system this project is utilizing

--- a/src/util/cache/cloneIntoCache.test.ts
+++ b/src/util/cache/cloneIntoCache.test.ts
@@ -1,13 +1,21 @@
 jest.mock('../../lib/constants', () => ({
   CACHE_DIR: 'home/uname/.emulsify/cache',
 }));
+jest.mock('../fs/findFileInCurrentPath', () => jest.fn());
+
 import cloneIntoCache from './cloneIntoCache';
+import findFileInCurrentPath from '../fs/findFileInCurrentPath';
+
 import fs from 'fs';
 import git from 'simple-git';
 
 const existsSyncMock = fs.existsSync as jest.Mock;
 const mkdirMock = fs.promises.mkdir as jest.Mock;
 const gitCloneMock = git().clone as jest.Mock;
+
+(findFileInCurrentPath as jest.Mock).mockReturnValue(
+  '/home/uname/projects/emulsify'
+);
 
 describe('cloneIntoCache', () => {
   beforeEach(() => {
@@ -33,7 +41,7 @@ describe('cloneIntoCache', () => {
     existsSyncMock.mockReturnValueOnce(false).mockReturnValueOnce(false);
     await cloneIntoCache('systems', ['cornflake'])(cloneOptions);
     expect(mkdirMock).toHaveBeenCalledWith(
-      'home/uname/.emulsify/cache/systems',
+      'home/uname/.emulsify/cache/systems/f556ea98d7e82a3bb86892c77634c0b3',
       {
         recursive: true,
       }
@@ -46,7 +54,7 @@ describe('cloneIntoCache', () => {
     await cloneIntoCache('systems', ['cornflake'])(cloneOptions);
     expect(gitCloneMock).toHaveBeenCalledWith(
       'repo-path',
-      'home/uname/.emulsify/cache/systems/cornflake',
+      'home/uname/.emulsify/cache/systems/f556ea98d7e82a3bb86892c77634c0b3/cornflake',
       { '--branch': 'branch-name' }
     );
   });
@@ -57,7 +65,7 @@ describe('cloneIntoCache', () => {
     await cloneIntoCache('systems', ['cornflake'])({ repository: 'repo-path' });
     expect(gitCloneMock).toHaveBeenCalledWith(
       'repo-path',
-      'home/uname/.emulsify/cache/systems/cornflake',
+      'home/uname/.emulsify/cache/systems/f556ea98d7e82a3bb86892c77634c0b3/cornflake',
       {}
     );
   });

--- a/src/util/cache/cloneIntoCache.ts
+++ b/src/util/cache/cloneIntoCache.ts
@@ -7,8 +7,6 @@ import { dirname } from 'path';
 
 import getCachedItemPath from './getCachedItemPath';
 
-const git = simpleGit();
-
 /**
  * Clones a repository into the cache (util) directory, if it does not already exist.
  *
@@ -24,9 +22,16 @@ export default function cloneIntoCache(
   return async ({ repository, checkout }: GitCloneOptions): Promise<void> => {
     const destination = getCachedItemPath(bucket, itemPath);
     const parentDir = dirname(destination);
+    let git = simpleGit();
 
-    // If the item is already in cache, return void. No work needed.
+    // If the item is already in cache, make sure it has the correct branch/tag/commit
+    // checked out and exit.
     if (existsSync(destination)) {
+      if (checkout) {
+        git = simpleGit(destination);
+        await git.fetch();
+        await git.checkout(checkout);
+      }
       return;
     }
 

--- a/src/util/cache/cloneIntoCache.ts
+++ b/src/util/cache/cloneIntoCache.ts
@@ -3,9 +3,9 @@ import type { GitCloneOptions } from '@emulsify-cli/git';
 
 import simpleGit from 'simple-git';
 import { existsSync, promises as fs } from 'fs';
-import { dirname, join } from 'path';
+import { dirname } from 'path';
 
-import { CACHE_DIR } from '../../lib/constants';
+import getCachedItemPath from './getCachedItemPath';
 
 const git = simpleGit();
 
@@ -18,13 +18,11 @@ const git = simpleGit();
  * @returns void, or throws an error if the repository could not be cloned.
  */
 export default function cloneIntoCache(
-  type: CacheBucket,
+  bucket: CacheBucket,
   itemPath: CacheItemPath
 ) {
   return async ({ repository, checkout }: GitCloneOptions): Promise<void> => {
-    // @TODO: Eventually, this needs to support being able to clone different copies of the
-    // same system for different projects.
-    const destination = join(CACHE_DIR, type, ...itemPath);
+    const destination = getCachedItemPath(bucket, itemPath);
     const parentDir = dirname(destination);
 
     // If the item is already in cache, return void. No work needed.

--- a/src/util/cache/copyItemFromCache.test.ts
+++ b/src/util/cache/copyItemFromCache.test.ts
@@ -1,3 +1,9 @@
+jest.mock('./getCachedItemPath', () =>
+  jest.fn(
+    () =>
+      '/home/uname/.emulsify/cache/systems/12345/compound/components/00-base/colors'
+  )
+);
 import { copy } from 'fs-extra';
 import copyItemFromCache from './copyItemFromCache';
 
@@ -9,7 +15,7 @@ describe('copyItemFromCache', () => {
       '/home/uname/Projects/drupal/web/themes/custom/cornflake/components/00-base/colors'
     );
     expect(copy).toHaveBeenCalledWith(
-      '/home/pcoffey/.emulsify/cache/systems/compound/components/00-base/colors',
+      '/home/uname/.emulsify/cache/systems/12345/compound/components/00-base/colors',
       '/home/uname/Projects/drupal/web/themes/custom/cornflake/components/00-base/colors'
     );
   });

--- a/src/util/cache/getCachedItemCheckout.test.ts
+++ b/src/util/cache/getCachedItemCheckout.test.ts
@@ -1,0 +1,20 @@
+jest.mock('./getCachedItemPath', () =>
+  jest.fn(() => '/home/uname/.emulsify/cache/systems/12345/compound')
+);
+import git from 'simple-git';
+import getCachedItemCheckout from './getCachedItemCheckout';
+
+const gitBranchMock = git().branch as jest.Mock;
+gitBranchMock.mockResolvedValue({
+  current: 'the-current-branch',
+});
+
+describe('getCachedItemCheckout', () => {
+  it('can grab the current checkout of the specified repository', async () => {
+    expect.assertions(2);
+    await expect(getCachedItemCheckout('systems', ['compound'])).resolves.toBe(
+      'the-current-branch'
+    );
+    expect(gitBranchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/util/cache/getCachedItemCheckout.ts
+++ b/src/util/cache/getCachedItemCheckout.ts
@@ -1,0 +1,22 @@
+import type { CacheBucket, CacheItemPath } from '@emulsify-cli/cache';
+
+import simpleGit from 'simple-git';
+import getCachedItemPath from './getCachedItemPath';
+
+/**
+ * Takes a cache bucket and item path, and returns the checkout value (git branch/tag/commit)
+ * that is currently checked out within the cloned item.
+ *
+ * @param type CacheBucket value that specifies what type of cache this repository is.
+ * @param itemPath array of strings describing the path to the item cache within the specified bucket.
+ *
+ * @returns string indicating the branch/tag/commit that is currently checked out.
+ */
+export default async function getCachedItemCheckout(
+  bucket: CacheBucket,
+  itemPath: CacheItemPath
+): Promise<string> {
+  const location = getCachedItemPath(bucket, itemPath);
+  const git = simpleGit(location);
+  return (await git.branch()).current;
+}

--- a/src/util/cache/getCachedItemPath.test.ts
+++ b/src/util/cache/getCachedItemPath.test.ts
@@ -1,14 +1,23 @@
 jest.mock('../../lib/constants', () => ({
   CACHE_DIR: 'home/uname/.emulsify/cache',
 }));
+jest.mock('../fs/findFileInCurrentPath', () => jest.fn());
+
+import findFileInCurrentPath from '../fs/findFileInCurrentPath';
 import getCachedItemPath from './getCachedItemPath';
+
+(findFileInCurrentPath as jest.Mock).mockReturnValue(
+  '/home/uname/projects/emulsify'
+);
 
 describe('getCachedItemPath', () => {
   it('can produce the path to a cached file if given a cache bucket, cache item name, and filename', () => {
     expect.assertions(2);
     expect(
       getCachedItemPath('systems', ['compound', 'system.emulsify.json'])
-    ).toBe('home/uname/.emulsify/cache/systems/compound/system.emulsify.json');
+    ).toBe(
+      'home/uname/.emulsify/cache/systems/f556ea98d7e82a3bb86892c77634c0b3/compound/system.emulsify.json'
+    );
     expect(
       getCachedItemPath('variants', [
         'compound',
@@ -16,7 +25,7 @@ describe('getCachedItemPath', () => {
         'variant.emulsify.json',
       ])
     ).toBe(
-      'home/uname/.emulsify/cache/variants/compound/drupal/variant.emulsify.json'
+      'home/uname/.emulsify/cache/variants/f556ea98d7e82a3bb86892c77634c0b3/compound/drupal/variant.emulsify.json'
     );
   });
 });

--- a/src/util/cache/getCachedItemPath.test.ts
+++ b/src/util/cache/getCachedItemPath.test.ts
@@ -1,12 +1,13 @@
 jest.mock('../../lib/constants', () => ({
   CACHE_DIR: 'home/uname/.emulsify/cache',
+  EMULSIFY_PROJECT_CONFIG_FILE: 'project.emulsify.json',
 }));
 jest.mock('../fs/findFileInCurrentPath', () => jest.fn());
 
 import findFileInCurrentPath from '../fs/findFileInCurrentPath';
 import getCachedItemPath from './getCachedItemPath';
 
-(findFileInCurrentPath as jest.Mock).mockReturnValue(
+const findFileMock = (findFileInCurrentPath as jest.Mock).mockReturnValue(
   '/home/uname/projects/emulsify'
 );
 
@@ -27,5 +28,12 @@ describe('getCachedItemPath', () => {
     ).toBe(
       'home/uname/.emulsify/cache/variants/f556ea98d7e82a3bb86892c77634c0b3/compound/drupal/variant.emulsify.json'
     );
+  });
+
+  it('throws an error if a project config file is not found', () => {
+    findFileMock.mockReturnValueOnce(undefined);
+    expect(() =>
+      getCachedItemPath('systems', ['compound', 'system.emulsify.json'])
+    ).toThrow('Unable to find project.emulsify.json');
   });
 });

--- a/src/util/cache/getCachedItemPath.ts
+++ b/src/util/cache/getCachedItemPath.ts
@@ -1,7 +1,9 @@
 import type { CacheBucket, CacheItemPath } from '@emulsify-cli/cache';
 
 import { join } from 'path';
-import { CACHE_DIR } from '../../lib/constants';
+import { createHash } from 'crypto';
+import { CACHE_DIR, EMULSIFY_PROJECT_CONFIG_FILE } from '../../lib/constants';
+import findFileInCurrentPath from '../fs/findFileInCurrentPath';
 
 /**
  * Accepts a cache bucket, item path, and item name, and returns the full
@@ -16,5 +18,16 @@ export default function getCachedItemPath(
   bucket: CacheBucket,
   itemPath: CacheItemPath
 ): string {
-  return join(CACHE_DIR, bucket, ...itemPath);
+  const projectPath = findFileInCurrentPath(EMULSIFY_PROJECT_CONFIG_FILE);
+
+  if (!projectPath) {
+    throw new Error(`Unable to find ${EMULSIFY_PROJECT_CONFIG_FILE}`);
+  }
+
+  return join(
+    CACHE_DIR,
+    bucket,
+    createHash('md5').update(projectPath).digest('hex'),
+    ...itemPath
+  );
 }

--- a/src/util/cache/getJsonFromCachedFile.test.ts
+++ b/src/util/cache/getJsonFromCachedFile.test.ts
@@ -1,3 +1,9 @@
+jest.mock('./getCachedItemPath', () =>
+  jest.fn(
+    () =>
+      '/home/uname/.emulsify/cache/systems/12345/compound/system.emulsify.json'
+  )
+);
 jest.mock('../../lib/constants', () => ({
   CACHE_DIR: 'home/uname/.emulsify/cache',
 }));
@@ -19,7 +25,7 @@ describe('getJsonFromCachedFile', () => {
       the: 'json',
     });
     expect(loadJsonMock).toHaveBeenCalledWith(
-      'home/uname/.emulsify/cache/systems/compound/system.emulsify.json'
+      '/home/uname/.emulsify/cache/systems/12345/compound/system.emulsify.json'
     );
   });
 

--- a/src/util/catchLater.test.ts
+++ b/src/util/catchLater.test.ts
@@ -3,6 +3,7 @@ import catchLater from './catchLater';
 describe('catchLater', () => {
   it('can prevent unhandled promise rejections when caught asynchronously', async () => {
     const promise = catchLater(
+      /* eslint-disable-next-line @typescript-eslint/require-await */
       (async () => {
         throw new Error('pancakes');
       })()
@@ -13,7 +14,7 @@ describe('catchLater', () => {
     try {
       await promise;
     } catch (e) {
-      expect(e.message).toBe('pancakes');
+      expect(e).toEqual(Error('pancakes'));
     }
   });
 });

--- a/src/util/catchLater.ts
+++ b/src/util/catchLater.ts
@@ -1,3 +1,5 @@
+import R from 'ramda';
+
 /**
  * Allows the promise passed as input to be asynchronously caught. If you
  * initialize a promise without a .catch() or without immediately awaiting it,
@@ -10,6 +12,6 @@
  * https://stackoverflow.com/questions/40920179/should-i-refrain-from-handling-promise-rejection-asynchronously
  */
 export default <R>(p: Promise<R>): Promise<R> => {
-  p.catch(() => {});
+  p.catch(R.identity);
   return p;
 };

--- a/src/util/project/installGeneralAssetsFromCache.test.ts
+++ b/src/util/project/installGeneralAssetsFromCache.test.ts
@@ -9,9 +9,12 @@ import installGeneralAssetsFromCache from './installGeneralAssetsFromCache';
 const findFileMock = (findFileInCurrentPath as jest.Mock).mockReturnValue(
   '/home/uname/Projects/cornflake/web/themes/custom/cornflake/project.emulsify.json'
 );
-(copyItemFromCache as jest.Mock).mockResolvedValue(true);
+const copyItemMock = (copyItemFromCache as jest.Mock).mockResolvedValue(true);
 
 describe('installGeneralAssetsFromCache', () => {
+  beforeEach(() => {
+    copyItemMock.mockClear();
+  });
   const system = {
     name: 'compound',
   } as EmulsifySystem;
@@ -45,17 +48,23 @@ describe('installGeneralAssetsFromCache', () => {
   it('copies all general files and directories into the Emulsify project', async () => {
     expect.assertions(2);
     await installGeneralAssetsFromCache(system, variant);
-    expect(copyItemFromCache).toHaveBeenNthCalledWith(
+    expect(copyItemMock).toHaveBeenNthCalledWith(
       1,
       'systems',
       ['compound', './components/00-base/00-defaults'],
       '/home/uname/Projects/cornflake/web/themes/custom/cornflake/components/00-base/00-defaults'
     );
-    expect(copyItemFromCache).toHaveBeenNthCalledWith(
+    expect(copyItemMock).toHaveBeenNthCalledWith(
       2,
       'systems',
       ['compound', './components/style.scss'],
       '/home/uname/Projects/cornflake/web/themes/custom/cornflake/components/style.scss'
     );
+  });
+
+  it('defaults directories/variants to empty arrays', async () => {
+    expect.assertions(1);
+    await installGeneralAssetsFromCache(system, {} as EmulsifyVariant);
+    expect(copyItemMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This PR introduces the following improvements:
 - Adds project-specific cache buckets so that if a user is making use of the same system/variant in different projects, the system/variant the CLI pulls from will be different in each case.
 - Makes `checkout` a requirement for Emulsify project config.
 - Automatically detects and records the default checkout/branch if none is specified during system installation.
 - Ensures that the cached repositories exist, and have the correct tag/commit/branch checked out before attempting to pull resources from the cached repository.