### PR TITLE
feat(30): add ability to specify init success messages per platform

### DIFF
--- a/src/handlers/init.ts
+++ b/src/handlers/init.ts
@@ -2,7 +2,6 @@ import R from 'ramda';
 import { join } from 'path';
 import { existsSync, promises as fs } from 'fs';
 import simpleGit from 'simple-git';
-import { cyan } from 'chalk';
 import ProgressBar from 'progress';
 
 import type { EmulsifyProjectConfiguration } from '@emulsify-cli/config';
@@ -18,6 +17,7 @@ import writeToJsonFile from '../util/fs/writeToJsonFile';
 import strToMachineName from '../util/strToMachineName';
 import installDependencies from '../util/project/installDependencies';
 import executeScript from '../util/fs/executeScript';
+import getInitSuccessMessageForPlatform from '../util/platform/getInitSuccessMessageForPlatform';
 import log from '../lib/log';
 import { EXIT_ERROR } from '../lib/constants';
 
@@ -154,30 +154,9 @@ export default function init(progress: InstanceType<typeof ProgressBar>) {
       });
 
       log('success', `Created an Emulsify project in ${target}.`);
-      log(
-        'info',
-        `Make sure you install the modules your Emulsify-based theme requires in order to function.`
-      );
-      log(
-        'verbose',
-        `
-      - composer require drupal/components
-      - composer require drupal/emulsify_twig
-      - drush en components emulsify_twig -y
-    `
-      );
-      log(
-        'info',
-        `Once the requirements have been installed, you will need to select a system to use, as Emulsify does not come with components by default.`
-      );
-      log(
-        'verbose',
-        `
-      ${cyan('List systems')}: emulsify system list
-      ${cyan('Install a system')}: emulsify system install "system-name"
-      ${cyan('Install default system')}: emulsify system install compound
-    `
-      );
+      getInitSuccessMessageForPlatform(
+        platformName
+      ).map(({ method, message }) => log(method, message));
     } catch (e) {
       log(
         'error',

--- a/src/util/platform/getInitSuccessMessageForPlatform.test.ts
+++ b/src/util/platform/getInitSuccessMessageForPlatform.test.ts
@@ -1,0 +1,35 @@
+import getInitSuccessMessageForPlatform from './getInitSuccessMessageForPlatform';
+
+// The unsafe assignment rule is disabled for this file because
+// it is important to use `expect.any`. There is no reason to test the
+// content of those messages, and doing so is especially odd due to the
+// character codes that come with chalk functions.
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+describe('getInitSuccessMessageForPlatform', () => {
+  it('can return init success log messages for a given platform', () => {
+    expect.assertions(1);
+    expect(getInitSuccessMessageForPlatform('drupal')).toEqual([
+      {
+        method: 'info',
+        message: expect.any(String),
+      },
+      {
+        method: 'verbose',
+        message: expect.any(String),
+      },
+      {
+        method: 'info',
+        message: expect.any(String),
+      },
+      {
+        method: 'verbose',
+        message: expect.any(String),
+      },
+    ]);
+  });
+
+  it('returns an empty array if the given platform does not correspond with any success messages', () => {
+    expect.assertions(1);
+    expect(getInitSuccessMessageForPlatform('java')).toEqual([]);
+  });
+});

--- a/src/util/platform/getInitSuccessMessageForPlatform.ts
+++ b/src/util/platform/getInitSuccessMessageForPlatform.ts
@@ -1,0 +1,48 @@
+import { LogMethod } from 'src/lib/log';
+import { cyan } from 'chalk';
+
+/**
+ * Returns the init success log messages for a given platform.
+ *
+ * @param platform name of platform.
+ * @returns array containing objects with a log method, and message.
+ */
+export default function getInitSuccessMessageForPlatform(
+  platform: string
+): {
+  method: LogMethod;
+  message: string;
+}[] {
+  if (platform === 'drupal') {
+    return [
+      {
+        method: 'info',
+        message:
+          'Make sure you install the modules your Emulsify-based theme requires in order to function.',
+      },
+      {
+        method: 'verbose',
+        message: `
+            - composer require drupal/components
+            - composer require drupal/emulsify_twig
+            - drush en components emulsify_twig -y
+            `,
+      },
+      {
+        method: 'info',
+        message:
+          'Once the requirements have been installed, you will need to select a system to use, as Emulsify does not come with components by default.',
+      },
+      {
+        method: 'verbose',
+        message: `
+            ${cyan('List systems')}: emulsify system list
+            ${cyan('Install a system')}: emulsify system install "system-name"
+            ${cyan('Install default system')}: emulsify system install compound
+            `,
+      },
+    ];
+  }
+
+  return [];
+}


### PR DESCRIPTION
Solves this issue: https://github.com/emulsify-ds/emulsify-cli/issues/30

Steps to test:
 - [x] Build the project and link it.
 - [x] Anywhere outside of the project dir, run `emulsify init "testing123" ./ --starter https://github.com/emulsify-ds/emulsify-drupal.git --checkout 2.x --platform drupal`. 
 - [x] Make sure you see success messages logged to the console after the initialization is complete.