### PR TITLE
feat(32): add a systemInstall hook execution step

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -10,6 +10,7 @@ export const EXIT_ERROR = 1;
 export const EMULSIFY_PROJECT_CONFIG_FILE = 'project.emulsify.json';
 export const EMULSIFY_PROJECT_HOOK_FOLDER = '.cli';
 export const EMULSIFY_PROJECT_HOOK_INIT = 'init.js';
+export const EMULSIFY_PROJECT_HOOK_SYSTEM_INSTALL = 'systemInstall.js';
 export const EMULSIFY_SYSTEM_CONFIG_FILE = 'system.emulsify.json';
 export const UTIL_DIR = join(homedir(), '.emulsify');
 export const CACHE_DIR = join(UTIL_DIR, 'cache');


### PR DESCRIPTION
Relevant issue: https://github.com/emulsify-ds/emulsify-cli/issues/32

No real need to test this functionally, there are no starters with systemInstall hooks. 