### PR TITLE
feat: add option to install all components at init

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -101,6 +101,7 @@ Options:
   -c --checkout <commit/branch/tag>  Commit, branch or tag of the base repository that should be checked out. MUST be provided if you are passing along
                                      a repository (-r or --repository). Tags or commit hashes are strongly preferable, because you want to ensure that
                                      you are using the same version of the system every time you install components, etc
+  -a --all                           Use this to install all available components within the specified system. Without this flag, only the required system components will be installed.
   -h, --help                         display help for command
 ```
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -199,7 +199,7 @@ emulsify component install card --force
 
 #### Installing all available components
 
-If you would like to simply install all components available withing the system you've selected, use the `--all` flag.
+If you would like to simply install all components available within the system you've selected, use the `--all` flag.
 
 Example usage:
 

--- a/src/handlers/systemInstall.ts
+++ b/src/handlers/systemInstall.ts
@@ -209,17 +209,30 @@ export default async function systemInstall(
   }
 
   try {
-    // Install all required components.
-    const requiredComponents = variantConf.components.filter(
+    // Install all required components or all available components.
+    const componentsList = variantConf.components;
+    const requiredComponents = componentsList.filter(
       ({ required }) => required === true
     );
-    for (const component of requiredComponents) {
-      await installComponentFromCache(
-        systemConf,
-        variantConf,
-        component.name,
-        true
-      );
+
+    if (options.all) {
+      for (const component of componentsList) {
+        await installComponentFromCache(
+          systemConf,
+          variantConf,
+          component.name,
+          true
+        );
+      }
+    } else {
+      for (const component of requiredComponents) {
+        await installComponentFromCache(
+          systemConf,
+          variantConf,
+          component.name,
+          true
+        );
+      }
     }
 
     // Install all global files and folders.

--- a/src/handlers/systemInstall.ts
+++ b/src/handlers/systemInstall.ts
@@ -215,24 +215,13 @@ export default async function systemInstall(
       ({ required }) => required === true
     );
 
-    if (options.all) {
-      for (const component of componentsList) {
-        await installComponentFromCache(
-          systemConf,
-          variantConf,
-          component.name,
-          true
-        );
-      }
-    } else {
-      for (const component of requiredComponents) {
-        await installComponentFromCache(
-          systemConf,
-          variantConf,
-          component.name,
-          true
-        );
-      }
+    for (const component of options.all ? componentsList : requiredComponents) {
+      await installComponentFromCache(
+        systemConf,
+        variantConf,
+        component.name,
+        true
+      );
     }
 
     // Install all global files and folders.

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ system
   )
   .option(
     '-a --all',
-    'Use this to install all available components, rather than specifying a single component to install'
+    'Use this to install all available components within the specified system. Without this flag, only the required system components will be installed.'
   )
   .description(
     'Install a system within an Emulsify project. You must specify either the name of an out-of-the-box system (such as compound), or a link to a git repository containing the system you want to install',

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,10 @@ system
     '-c --checkout <commit/branch/tag>',
     'Commit, branch or tag of the base repository that should be checked out. MUST be provided if you are passing along a repository (-r or --repository). Tags or commit hashes are strongly preferable, because you want to ensure that you are using the same version of the system every time you install components, etc'
   )
+  .option(
+    '-a --all',
+    'Use this to install all available components, rather than specifying a single component to install'
+  )
   .description(
     'Install a system within an Emulsify project. You must specify either the name of an out-of-the-box system (such as compound), or a link to a git repository containing the system you want to install',
     {

--- a/src/types/handlers.d.ts
+++ b/src/types/handlers.d.ts
@@ -13,6 +13,7 @@ declare module '@emulsify-cli/handlers' {
     repository?: string | void;
     checkout?: string | void;
     variant?: string | void;
+    all?: boolean;
   };
 
   export type InstallComponentHandlerOptions = {

--- a/src/util/platform/getInitSuccessMessageForPlatform.ts
+++ b/src/util/platform/getInitSuccessMessageForPlatform.ts
@@ -38,7 +38,12 @@ export default function getInitSuccessMessageForPlatform(
         message: `
             ${cyan('List systems')}: emulsify system list
             ${cyan('Install a system')}: emulsify system install "system-name"
-            ${cyan('Install default system')}: emulsify system install compound
+            ${cyan(
+              'Install default system with default components'
+            )}: emulsify system install compound
+            ${cyan(
+              'Install default system with all components'
+            )}: emulsify system install compound --all
             `,
       },
     ];


### PR DESCRIPTION
**Summary**

This PR fixes/implements the following:

- Adds option to install all default system components at the start

**How to review this PR**
- [ ] Pull this branch down, run `npm build` and `npm link`
- [ ] Create a new Drupal project somewhere. I used `composer create-project drupal/recommended-project drupal-folder`
- [ ] Go into that folder and run `npm link @emulsify/cli` (make sure there are no warnings/errors)
- [ ] Run `emulsify init "Theme Name"`. You'll see a new option listed that allows an individual to install all components instead of just the default (screen shot below)
- [ ] Install all the components. `emulsify system install compound --all`. To verify, you can go to your theme directory and checkout the components. For example, the `card` is not a default component. 

![Screen Shot 2022-02-25 at 9 57 20 AM](https://user-images.githubusercontent.com/8405274/155737427-2a94fc51-d920-41b4-8cc3-2ec649e0e90f.png)

**Closing issues**
Closes #11
