### PR TITLE
Allow update of system version

### DIFF
--- a/src/handlers/componentInstall.ts
+++ b/src/handlers/componentInstall.ts
@@ -64,6 +64,7 @@ export default async function componentInstall(
   const systemConf: EmulsifySystem | void = await getJsonFromCachedFile(
     'systems',
     [systemName],
+    emulsifyConfig.system.checkout,
     EMULSIFY_SYSTEM_CONFIG_FILE
   );
 

--- a/src/handlers/componentList.ts
+++ b/src/handlers/componentList.ts
@@ -58,6 +58,7 @@ export default async function componentList(): Promise<void> {
   const systemConf: EmulsifySystem | void = await getJsonFromCachedFile(
     'systems',
     [systemName],
+    emulsifyConfig.system.checkout,
     EMULSIFY_SYSTEM_CONFIG_FILE
   );
 

--- a/src/handlers/systemInstall.ts
+++ b/src/handlers/systemInstall.ts
@@ -119,6 +119,7 @@ export default async function systemInstall(
   const systemConf: EmulsifySystem | void = await getJsonFromCachedFile(
     'systems',
     [repo.name],
+    repo.checkout,
     EMULSIFY_SYSTEM_CONFIG_FILE
   );
 

--- a/src/types/cache.d.ts
+++ b/src/types/cache.d.ts
@@ -4,4 +4,5 @@
 declare module '@emulsify-cli/cache' {
   export type CacheBucket = 'systems' | 'variants';
   export type CacheItemPath = string[];
+  export type CacheCheckout = string | void;
 }

--- a/src/util/cache/cloneIntoCache.test.ts
+++ b/src/util/cache/cloneIntoCache.test.ts
@@ -40,7 +40,7 @@ describe('cloneIntoCache', () => {
     existsSyncMock.mockReturnValueOnce(false).mockReturnValueOnce(false);
     await cloneIntoCache('systems', ['cornflake'])(cloneOptions);
     expect(mkdirMock).toHaveBeenCalledWith(
-      'home/uname/.emulsify/cache/systems/f556ea98d7e82a3bb86892c77634c0b3',
+      'home/uname/.emulsify/cache/systems/2a39785f5c873d7a694ac505a8123bb9',
       {
         recursive: true,
       }
@@ -53,7 +53,7 @@ describe('cloneIntoCache', () => {
     await cloneIntoCache('systems', ['cornflake'])(cloneOptions);
     expect(gitCloneMock).toHaveBeenCalledWith(
       'repo-path',
-      'home/uname/.emulsify/cache/systems/f556ea98d7e82a3bb86892c77634c0b3/cornflake',
+      'home/uname/.emulsify/cache/systems/2a39785f5c873d7a694ac505a8123bb9/cornflake',
       { '--branch': 'branch-name' }
     );
   });
@@ -64,7 +64,7 @@ describe('cloneIntoCache', () => {
     await cloneIntoCache('systems', ['cornflake'])({ repository: 'repo-path' });
     expect(gitCloneMock).toHaveBeenCalledWith(
       'repo-path',
-      'home/uname/.emulsify/cache/systems/f556ea98d7e82a3bb86892c77634c0b3/cornflake',
+      'home/uname/.emulsify/cache/systems/6342daf21717ab9c095fcddf7943e4e1/cornflake',
       {}
     );
   });

--- a/src/util/cache/cloneIntoCache.ts
+++ b/src/util/cache/cloneIntoCache.ts
@@ -20,7 +20,7 @@ export default function cloneIntoCache(
   itemPath: CacheItemPath
 ) {
   return async ({ repository, checkout }: GitCloneOptions): Promise<void> => {
-    const destination = getCachedItemPath(bucket, itemPath);
+    const destination = getCachedItemPath(bucket, itemPath, checkout);
     const parentDir = dirname(destination);
 
     // If the item is already in cache, simply return.

--- a/src/util/cache/getCachedItemPath.test.ts
+++ b/src/util/cache/getCachedItemPath.test.ts
@@ -15,25 +15,33 @@ describe('getCachedItemPath', () => {
   it('can produce the path to a cached file if given a cache bucket, cache item name, and filename', () => {
     expect.assertions(2);
     expect(
-      getCachedItemPath('systems', ['compound', 'system.emulsify.json'])
+      getCachedItemPath(
+        'systems',
+        ['compound', 'system.emulsify.json'],
+        'branch-name'
+      )
     ).toBe(
-      'home/uname/.emulsify/cache/systems/f556ea98d7e82a3bb86892c77634c0b3/compound/system.emulsify.json'
+      'home/uname/.emulsify/cache/systems/2a39785f5c873d7a694ac505a8123bb9/compound/system.emulsify.json'
     );
     expect(
-      getCachedItemPath('variants', [
-        'compound',
-        'drupal',
-        'variant.emulsify.json',
-      ])
+      getCachedItemPath(
+        'variants',
+        ['compound', 'drupal', 'variant.emulsify.json'],
+        'branch-name'
+      )
     ).toBe(
-      'home/uname/.emulsify/cache/variants/f556ea98d7e82a3bb86892c77634c0b3/compound/drupal/variant.emulsify.json'
+      'home/uname/.emulsify/cache/variants/2a39785f5c873d7a694ac505a8123bb9/compound/drupal/variant.emulsify.json'
     );
   });
 
   it('throws an error if a project config file is not found', () => {
     findFileMock.mockReturnValueOnce(undefined);
     expect(() =>
-      getCachedItemPath('systems', ['compound', 'system.emulsify.json'])
+      getCachedItemPath(
+        'systems',
+        ['compound', 'system.emulsify.json'],
+        'branch-name'
+      )
     ).toThrow('Unable to find project.emulsify.json');
   });
 });

--- a/src/util/cache/getCachedItemPath.ts
+++ b/src/util/cache/getCachedItemPath.ts
@@ -1,4 +1,8 @@
-import type { CacheBucket, CacheItemPath } from '@emulsify-cli/cache';
+import type {
+  CacheBucket,
+  CacheItemPath,
+  CacheCheckout,
+} from '@emulsify-cli/cache';
 
 import { join } from 'path';
 import { createHash } from 'crypto';
@@ -11,12 +15,13 @@ import findFileInCurrentPath from '../fs/findFileInCurrentPath';
  *
  * @param bucket name of the bucket containing the cached item.
  * @param itemPath array containing segments of the path to the cached item within the specified bucket.
- * @param item name of the cached item.
+ * @param checkout commit, branch, or tag of the system this project is utilizing.
  * @returns string containing the full path to the specified cached item.
  */
 export default function getCachedItemPath(
   bucket: CacheBucket,
-  itemPath: CacheItemPath
+  itemPath: CacheItemPath,
+  checkout: CacheCheckout
 ): string {
   const projectPath = findFileInCurrentPath(EMULSIFY_PROJECT_CONFIG_FILE);
 
@@ -27,7 +32,9 @@ export default function getCachedItemPath(
   return join(
     CACHE_DIR,
     bucket,
-    createHash('md5').update(projectPath).digest('hex'),
+    createHash('md5')
+      .update(`MBR${String(projectPath)}${String(checkout)}`)
+      .digest('hex'),
     ...itemPath
   );
 }

--- a/src/util/cache/getJsonFromCachedFile.test.ts
+++ b/src/util/cache/getJsonFromCachedFile.test.ts
@@ -20,7 +20,12 @@ describe('getJsonFromCachedFile', () => {
   it('can load and parse the JSON from a file stored in cache', async () => {
     expect.assertions(2);
     await expect(
-      getJsonFromCachedFile('systems', ['compound'], 'system.emulsify.json')
+      getJsonFromCachedFile(
+        'systems',
+        ['compound'],
+        'branch-name',
+        'system.emulsify.json'
+      )
     ).resolves.toEqual({
       the: 'json',
     });
@@ -33,7 +38,12 @@ describe('getJsonFromCachedFile', () => {
     expect.assertions(1);
     loadJsonMock.mockResolvedValueOnce(undefined);
     await expect(
-      getJsonFromCachedFile('systems', ['compound'], 'system.emulsify.json')
+      getJsonFromCachedFile(
+        'systems',
+        ['compound'],
+        'branch-name',
+        'system.emulsify.json'
+      )
     ).resolves.toBe(undefined);
   });
 });

--- a/src/util/cache/getJsonFromCachedFile.ts
+++ b/src/util/cache/getJsonFromCachedFile.ts
@@ -1,4 +1,8 @@
-import type { CacheBucket, CacheItemPath } from '@emulsify-cli/cache';
+import type {
+  CacheBucket,
+  CacheItemPath,
+  CacheCheckout,
+} from '@emulsify-cli/cache';
 
 import getCachedItemPath from './getCachedItemPath';
 import loadJsonFile from '../fs/loadJsonFile';
@@ -6,9 +10,10 @@ import loadJsonFile from '../fs/loadJsonFile';
 export default async function getJsonFromCachedFile<Output>(
   bucket: CacheBucket,
   itemPath: CacheItemPath,
+  checkout: CacheCheckout,
   fileName: string
 ): Promise<Output | void> {
   return loadJsonFile<Output>(
-    getCachedItemPath(bucket, [...itemPath, fileName])
+    getCachedItemPath(bucket, [...itemPath, fileName], checkout)
   );
 }


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This change allows users to update the version of their design system in the project.emulsify.json file and have the new version available to the CLI. Previously, a developer would have to delete the cached version to fetch any changes. This PR addresses https://github.com/emulsify-ds/emulsify-cli/issues/71

- Alters the path of the cached design system to include a specific 'checkout' parameter (commit, branch, or tag of the system this project is utilizing).
- Updates tests to reflect the changed paths. This path is stored as an md5 hash and is based on the repo URL concatinated with the checkout parameter.
- Updates any function calling or storing design system data to use the new cache path.

Open questions:
- Is this the best approach? The whole premise of using this md5 hash seems flawed. While this works, we are caching more than we need to. There is little reason to maintain multiple versions of a design system locally. Even if we do not want to refactor anything, we may want to consider adding a cache-clear mechanism to remove unwanted versions.
- Will this work for non-tagged versions? This change updates a few functions that access the 'checkout' parameter in different ways. Technically this variable may be void. We may want to brainstorm some test cases before merging this work.

**How to review this PR**
- [x] Create a drupal project `composer create-project drupal/recommended-project cli-update`
- [x]  Initialize a theme `emulsify init "My Theme"`
- [x] cd into the theme `cd web/themes/custom/my_theme`
- [x] Install a system `emulsify system install --repository https://github.com/yalesites-org/component-library-twig.git --checkout v1.7.0`
- [x] Verify you do not have access to the "accordion" component `emulsify component list`
- [x] Edit the theme's `project.emulsify.json` and change the "checkout" from v1.7.0 to v1.8.0
- [x] Verify you now DO have access to the accordion component `emulsify component list`
- [x] Edit the theme's project.emulsify.json and change the "checkout" from v1.8.0 back to v1.7.0
- [x] Verify that the accordion component is once again gone `emulsify component list`

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Closes #71
