### PR TITLE
feat(36): adding latest tag when available

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -3,8 +3,13 @@ jest.mock('simple-git', () => {
     clone: jest.fn(),
     branch: jest.fn(),
     checkout: jest.fn(),
-    fetch: jest.fn(),
+    fetch: jest.fn().mockReturnThis(),
     pull: jest.fn(),
+    init: jest.fn().mockReturnThis(),
+    addRemote: jest.fn().mockReturnThis(),
+    tags: jest.fn(() => {
+      return { latest: '' };
+    }),
   };
 
   return jest.fn(() => mockGit);

--- a/src/handlers/systemInstall.ts
+++ b/src/handlers/systemInstall.ts
@@ -19,6 +19,7 @@ import getAvailableSystems from '../util/system/getAvailableSystems';
 import getGitRepoNameFromUrl from '../util/getGitRepoNameFromUrl';
 import cloneIntoCache from '../util/cache/cloneIntoCache';
 import getCachedItemCheckout from '../util/cache/getCachedItemCheckout';
+import getRepositoryLatestTag from '../util/getRepositoryLatestTag';
 import installComponentFromCache from '../util/project/installComponentFromCache';
 import installGeneralAssetsFromCache from '../util/project/installGeneralAssetsFromCache';
 import getJsonFromCachedFile from '../util/cache/getJsonFromCachedFile';
@@ -109,10 +110,16 @@ export default async function systemInstall(
     );
   }
 
+  let checkout = repo.checkout;
+  // Attempt to get latest tag if no branch was supplied.
+  if (!checkout) {
+    checkout = await getRepositoryLatestTag(repo.repository);
+  }
+
   // Clone the system into the cache.
   await cloneIntoCache('systems', [repo.name])({
     repository: repo.repository,
-    checkout: repo.checkout,
+    checkout: checkout,
   });
 
   // Load the system configuration file.

--- a/src/util/getRepositoryLatestTag.test.ts
+++ b/src/util/getRepositoryLatestTag.test.ts
@@ -1,0 +1,26 @@
+import getRepositoryLatestTag from './getRepositoryLatestTag';
+import git from 'simple-git';
+
+const gitTagsMock = git().tags as jest.Mock;
+
+describe('getLatestRepositoryTag', () => {
+  beforeEach(() => {
+    gitTagsMock.mockClear();
+  });
+  it('Can get latest tag from repository url', async () => {
+    expect.assertions(1);
+    gitTagsMock.mockReturnValueOnce({ latest: '1.5.0' });
+    const latest = await getRepositoryLatestTag(
+      'git@github.com:emulsify-ds/compound.git'
+    );
+    expect(latest).toBe('1.5.0');
+  });
+
+  it('Can return empty if no latest tag is found', async () => {
+    expect.assertions(1);
+    const latest = await getRepositoryLatestTag(
+      'git@github.com:emulsify-ds/compoun.git'
+    );
+    expect(latest).toBe('');
+  });
+});

--- a/src/util/getRepositoryLatestTag.ts
+++ b/src/util/getRepositoryLatestTag.ts
@@ -1,0 +1,20 @@
+import simpleGit from 'simple-git';
+
+const git = simpleGit();
+
+/**
+ * Helper function to get the latest tag for a given repository url.
+ *
+ * @param url git url to use
+ * @returns string of the latest tag or undefined.
+ */
+export default async function getRepositoryLatestTag(
+  url: string
+): Promise<string | undefined> {
+  const repositoryTags = await git
+    .init()
+    .addRemote('origin', url)
+    .fetch()
+    .tags();
+  return repositoryTags.latest;
+}


### PR DESCRIPTION
<!-- 

A similar Pull Request (PR) may already be submitted!

Please search among the PRs before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.

-->

**Summary**

This is a simple change to get the latest tag for a given system when a specific branch or tag is not supplied. I've added a helper function for the future to get the latest tag of a given repository if we need or want to do that with starter installs later as well.

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Previously we were just checking out the latest on the default branch of the system which may not always be ready for production use. Defaulting to tag should be safer.

**How to review this PR**
<!-- Provide step-by-step instructions to functionally test this PR. -->
<!-- Ensure that your code passing the repo's linting standards. -->
- [x] Take note of the cached systems in `~/.emulsify/cache/systems`. These may need to be cleared/deleted in order to tell that this is pulling the desired tag or branch.
- [x] Pull this branch for emulsify cli
- [x] In the repo directory run `npm run build` and `npm link`
- [x] In a Drupal site, make sure you are using the same node version as in the emulsify-cli directory.
- [x] Run `emulsify init "some test repository"`
- [x] Change directories into the newly installed emulsify theme instance
- [x] Run `emulsify system install compound`
- [x] Latest compound version should be installed
- [x] Check the cached systems to confirm that the latest tag version is present in the cache now.
- [x] Delete this theme and run the emulsify theme install again but when installing compound supply a branch like `emulsify system install --repository git@github.com:emulsify-ds/compound.git --checkout main`
- [x] The latest on the default branch should be installed for compound
- [x] Check the cached systems to confirm that the latest on the main branch was pulled into cache. You can tell it is correct because git will be set to the main branch in the compound directory for the cached version.

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Closes #36 
