### PR TITLE
fix: gives user a specific error message when the repository URL does not end in .git

### DIFF
--- a/src/handlers/systemInstall.ts
+++ b/src/handlers/systemInstall.ts
@@ -43,13 +43,21 @@ export async function getSystemRepoInfo(
 ): Promise<(GitCloneOptions & { name: string }) | void> {
   // If a repository and checkout were specified, use that to return system information.
   if (repository && checkout) {
-    const repoName = getGitRepoNameFromUrl(repository);
-    if (repoName) {
-      return {
-        name: repoName,
-        repository,
-        checkout,
-      };
+    try {
+      const repoName = getGitRepoNameFromUrl(repository);
+      if (repoName) {
+        return {
+          name: repoName,
+          repository,
+          checkout,
+        };
+      }
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        return log('error', error.message, EXIT_ERROR);
+      } else {
+        throw error;
+      }
     }
   }
 

--- a/src/util/getGitRepoNameFromUrl.test.ts
+++ b/src/util/getGitRepoNameFromUrl.test.ts
@@ -17,11 +17,13 @@ describe('getGitRepoNameFromUrl', () => {
     ).toBe('emulsify-drupal');
   });
 
-  it('can return void if given an invalid git url', () => {
+  it('can throw an Error if given an invalid git url', () => {
     expect.assertions(2);
-    expect(getGitRepoNameFromUrl('')).toBe(undefined);
-    expect(
-      getGitRepoNameFromUrl('https://github.com/emulsify-ds/emulsify-drupal')
-    ).toBe(undefined);
+    expect(() => {
+      getGitRepoNameFromUrl('');
+    }).toThrow(Error);
+    expect(() => {
+      getGitRepoNameFromUrl('https://github.com/emulsify-ds/emulsify-drupal');
+    }).toThrow(Error);
   });
 });

--- a/src/util/getGitRepoNameFromUrl.ts
+++ b/src/util/getGitRepoNameFromUrl.ts
@@ -14,7 +14,7 @@ export default function getGitRepoNameFromUrl(url: string): string | void {
 
   // If no .git extension is provided, then this is an invalid git url.
   if (!gitName.includes('.git')) {
-    return undefined;
+    throw new Error('The repository URL must end in .git.');
   }
   return R.head(gitName.split('.'));
 }


### PR DESCRIPTION
**Summary**

This PR fixes:

- https://github.com/emulsify-ds/emulsify-cli/issues/70

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

When the user attempts to install a system using a repository url but the url does not end in .git, one of two things happens:

If the user also named a system in the command (ie compound), the system is installed, ignoring the user's `--repository` and `--checkout` flags, as identified in https://github.com/emulsify-ds/emulsify-cli/issues/70.

If no system was named, emulsify gives an error message:

`'Unable to download specified system. You must either specify a valid name of an out-of-the-box system using the --name flag, or specify a valid repository and branch/tag/commit using the --repository and --checkout flags.',`

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

If the user took the trouble to enter the URL of a repository but the repository URL is not valid, they should be told about the error.

**Documentation Update (required)**

None. Documentation already gives an example of correctly using the `emulsify system install` command.

**How to review this PR**
<!-- Provide step-by-step instructions to functionally test this PR. -->
<!-- Ensure that your code passing the repo's linting standards. -->
- [ ] Clone the branch for this PR exit-on-error-when-repository-url-is-invalid
- [ ] `npm install`
- [ ] `npm run build`
- [ ] `npm link` 
- [ ] [Create a standalone installation](https://docs.emulsify.info/emulsify-drupal/emulsify-drupal#standalone-for-prototyping-outside-of-a-drupal-install) of emulsify
- [ ]  initialize the a project  `emulsify init standalone themes -p drupal`
- [ ] `cd themes/standalone`
- [ ] try to install a system, but give a bad repository url `emulsify system install --repository https://github.com/emulsify-ds/compound --checkout 1.6.1`
- [ ] see helpful error message
- [ ] fix the repository url and try to install the system again `emulsify system install --repository https://github.com/emulsify-ds/compound.git --checkout 1.6.1`
- [ ] see success message and verify compound is installed

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Closes #70 
