### PR TITLE
feat: add version command option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -96,4 +96,8 @@ component
   )
   .action(componentInstall);
 
+// Because './package.json' is outside of our defined rootDir of ./src
+// in tsconfig, we need to disable the next line.
+// eslint-disable-next-line
+program.version(require('./package.json').version);
 void program.parseAsync(process.argv);


### PR DESCRIPTION
## Summary
Adds the version command option so that users can check on Emulsify CLI's version

## How to review this pull request
* Pull down the branch, and run `npm run watch` 
* Type `emulsify --help` and see that new version options are there
* Type `emulsify --version` to see the current version

## Closing issues
Closes #183 

### Notes
- We should start doing version releases as the CLI package is still version `0.0.0-development`
- Fun fact: I spent 10x more time setting up CLI and fighting Typescript than the actual work 🙃 