### PR TITLE
Add UI Kit to systems

### DIFF
--- a/src/util/system/getAvailableSystems.test.ts
+++ b/src/util/system/getAvailableSystems.test.ts
@@ -9,6 +9,11 @@ describe('getAvailableSystems', () => {
         repository: 'https://github.com/emulsify-ds/compound.git',
         platforms: ['drupal'],
       },
+      {
+        name: 'emulsify-ui-kit',
+        repository: 'https://github.com/emulsify-ds/emulsify-ui-kit.git',
+        platforms: ['drupal'],
+      },
     ]);
   });
 });

--- a/src/util/system/getAvailableSystems.ts
+++ b/src/util/system/getAvailableSystems.ts
@@ -19,5 +19,10 @@ export default async function getAvailableSystems(): Promise<
       repository: 'https://github.com/emulsify-ds/compound.git',
       platforms: ['drupal'],
     },
+    {
+      name: 'emulsify-ui-kit',
+      repository: 'https://github.com/emulsify-ds/emulsify-ui-kit.git',
+      platforms: ['drupal'],
+    },
   ];
 }


### PR DESCRIPTION
## Summary

Adds Emulsify UI Kit as an allowed system to install via the CLI

This PR fixes/implements the following **bugs/features**

- Adds Emulsify UI Kit as an allowed system to install via the CLI

The Emulsify UI Kit is almost ready for production and this grants the CLI the ability to quickly install it instead of just the original system, `compound`

## Documentation update (required)

To install the new Emulsify UI Kit into an existing Emulsify-based project, run the following command from within the root of your custom Emulsify theme directory:

`emulsify system install emulsify-ui-kit`

## How to review this pull request
- [x] Clone this repo locally
- [x] Go into the directory and change to this branch `git checkout add-ui-kit`
- [x] Run `npm install`
- [x] Run `npm run build`
- [x] Run `npm link`
- [x] Run `which emulsify`
- [x] Go to the directory where Emulsify is currently installed on your local system - I.e. to the place where there is a symlink to emulsify. Something like this when you run `ls -la`:

```
lrwxr-xr-x  1 user  staff    47B Aug 29 22:06 emulsify -> ../lib/node_modules/@emulsify/cli/dist/index.js
```
- [x] Run `npm link path-to-cloned-repo/emulsify-cli`
- [x] Create an Emulsify theme (With the new 5.0 version, you can run `drush emulsify my-theme-name` from the root of the Drupal project to create a custom Emulsify theme
- [x] From within the root of that newly created theme, run `emulsify system install emulsify-ui-kit`
- [x] Verify that a new `src` directory is created in your custom theme and that it contains some components from the UI kit
- [x] To revert your copy of emulsify, I haven't found a good way using `npm unlink` so, I simply deleted `../lib/node_modules/@emulsify` and the symlink in `~/.nvm/versions/node/v20.17.0/bin` entirely and re-ran `npm install -g @emulsify/cli`
