### PR TITLE
feat: Add no-platform starter as default init setup

### DIFF
--- a/src/handlers/init.test.ts
+++ b/src/handlers/init.test.ts
@@ -21,9 +21,9 @@ const rmdirMock = (fs.promises.rmdir as jest.Mock).mockReturnValue(true);
 const gitCloneMock = git().clone as jest.Mock;
 const getPlatformInfoMock = (getPlatformInfo as jest.Mock).mockReturnValue({
   root,
-  name: 'drupal',
-  emulsifyParentDirectory: `${root}/themes`,
-  platformMajorVersion: 9,
+  name: 'none',
+  emulsifyParentDirectory: `${root}`,
+  platformMajorVersion: 1,
 });
 const logMock = log as jest.Mock;
 const writeJsonFileMock = writeToJsonFile as jest.Mock;
@@ -43,24 +43,24 @@ describe('init', () => {
     expect.assertions(3);
     await init(progress)('cornflake');
     expect(gitCloneMock).toHaveBeenCalledWith(
-      'https://github.com/emulsify-ds/emulsify-drupal.git',
-      '/home/uname/Projects/cornflake/themes/cornflake',
-      { '--branch': 'master' },
+      'https://github.com/emulsify-ds/emulsify-starter',
+      '/home/uname/Projects/cornflake/cornflake',
+      { '--branch': 'develop' },
     );
     expect(rmdirMock).toHaveBeenCalledWith(
-      '/home/uname/Projects/cornflake/themes/cornflake/.git',
+      '/home/uname/Projects/cornflake/cornflake/.git',
       { recursive: true },
     );
     expect(writeJsonFileMock).toHaveBeenCalledWith(
-      '/home/uname/Projects/cornflake/themes/cornflake/project.emulsify.json',
+      '/home/uname/Projects/cornflake/cornflake/project.emulsify.json',
       {
         project: {
-          platform: 'drupal',
+          platform: 'none',
           machineName: 'cornflake',
           name: 'cornflake',
         },
         starter: {
-          repository: 'https://github.com/emulsify-ds/emulsify-drupal.git',
+          repository: 'https://github.com/emulsify-ds/emulsify-starter',
         },
       },
     );
@@ -70,7 +70,8 @@ describe('init', () => {
     expect.assertions(5);
     await init(progress)('cornflake');
     expect(progress.tick).toHaveBeenNthCalledWith(1, 10, {
-      message: 'using starter for drupal, validating config',
+      message:
+        'using starter for none as the selected platform, validating config',
     });
     expect(progress.tick).toHaveBeenNthCalledWith(2, 10, {
       message: 'validation complete, cloning starter',
@@ -89,14 +90,14 @@ describe('init', () => {
 
   it('can clone an Emulsify starter based on CLI input, and log a success message upon completion', async () => {
     expect.assertions(2);
-    await init(progress)('cornflake', `${root}/themes/subDir`, {
-      starter: 'https://github.com/cornflake-ds/cornflake-drupal.git',
-      checkout: '5.6x',
+    await init(progress)('cornflake', `${root}`, {
+      starter: 'https://github.com/emulsify-ds/emulsify-starter',
+      checkout: 'develop',
     });
     expect(gitCloneMock).toHaveBeenCalledWith(
-      'https://github.com/cornflake-ds/cornflake-drupal.git',
-      '/home/uname/Projects/cornflake/themes/subDir/cornflake',
-      { '--branch': '5.6x' },
+      'https://github.com/emulsify-ds/emulsify-starter',
+      '/home/uname/Projects/cornflake/cornflake',
+      { '--branch': 'develop' },
     );
     expect(logMock).toHaveBeenCalledTimes(5);
   });
@@ -104,13 +105,13 @@ describe('init', () => {
   it('can clone an Emulsify starter without a provided checkout', async () => {
     expect.assertions(1);
     getPlatformInfoMock.mockReturnValueOnce(undefined);
-    await init(progress)('cornflake', `${root}/themes/subDir`, {
-      starter: 'https://github.com/cornflake-ds/cornflake-drupal.git',
+    await init(progress)('cornflake', `${root}`, {
+      starter: 'https://github.com/emulsify-ds/emulsify-starter',
       platform: 'wordpress',
     });
     expect(gitCloneMock).toHaveBeenCalledWith(
-      'https://github.com/cornflake-ds/cornflake-drupal.git',
-      '/home/uname/Projects/cornflake/themes/subDir/cornflake',
+      'https://github.com/emulsify-ds/emulsify-starter',
+      '/home/uname/Projects/cornflake/cornflake',
       {},
     );
   });
@@ -119,7 +120,7 @@ describe('init', () => {
     expect.assertions(1);
     await init(progress)('cornflake');
     expect(installDependencies).toHaveBeenCalledWith(
-      '/home/uname/Projects/cornflake/themes/cornflake',
+      '/home/uname/Projects/cornflake/cornflake',
     );
   });
 
@@ -128,7 +129,7 @@ describe('init', () => {
     existsSyncMock.mockReturnValueOnce(false).mockReturnValueOnce(true);
     await init(progress)('cornflake');
     expect(executeScript).toHaveBeenCalledWith(
-      '/home/uname/Projects/cornflake/themes/cornflake/.cli/init.js',
+      '/home/uname/Projects/cornflake/cornflake/.cli/init.js',
     );
   });
 
@@ -150,7 +151,7 @@ describe('init', () => {
     await init(progress)('cornflake');
     expect(logMock).toHaveBeenCalledWith(
       'error',
-      'Unable to pull down https://github.com/emulsify-ds/emulsify-drupal.git: Error: Does not exist!',
+      'Unable to pull down https://github.com/emulsify-ds/emulsify-starter: Error: Does not exist!',
       1,
     );
   });
@@ -176,7 +177,7 @@ describe('init', () => {
     await init(progress)('cornflake', root);
     expect(logMock).toHaveBeenCalledWith(
       'error',
-      'Unable to find an Emulsify starter for your project. Please specify one using the --starter flag: emulsify init myTheme --starter https://github.com/emulsify-ds/emulsify-drupal.git',
+      'Unable to find an Emulsify starter for your project. Please specify one using the --starter flag: emulsify init myTheme --starter https://github.com/emulsify-ds/emulsify-starter',
       1,
     );
   });
@@ -187,7 +188,7 @@ describe('init', () => {
     await init(progress)('cornflake');
     expect(logMock).toHaveBeenCalledWith(
       'error',
-      'The intended target is already occupied: /home/uname/Projects/cornflake/themes/cornflake',
+      'The intended target is already occupied: /home/uname/Projects/cornflake/cornflake',
       1,
     );
   });

--- a/src/handlers/init.test.ts
+++ b/src/handlers/init.test.ts
@@ -45,7 +45,7 @@ describe('init', () => {
     expect(gitCloneMock).toHaveBeenCalledWith(
       'https://github.com/emulsify-ds/emulsify-starter',
       '/home/uname/Projects/cornflake/cornflake',
-      { '--branch': 'develop' },
+      { '--branch': 'main' },
     );
     expect(rmdirMock).toHaveBeenCalledWith(
       '/home/uname/Projects/cornflake/cornflake/.git',
@@ -92,12 +92,12 @@ describe('init', () => {
     expect.assertions(2);
     await init(progress)('cornflake', `${root}`, {
       starter: 'https://github.com/emulsify-ds/emulsify-starter',
-      checkout: 'develop',
+      checkout: 'main',
     });
     expect(gitCloneMock).toHaveBeenCalledWith(
       'https://github.com/emulsify-ds/emulsify-starter',
       '/home/uname/Projects/cornflake/cornflake',
-      { '--branch': 'develop' },
+      { '--branch': 'main' },
     );
     expect(logMock).toHaveBeenCalledTimes(5);
   });

--- a/src/handlers/init.ts
+++ b/src/handlers/init.ts
@@ -57,7 +57,7 @@ export default function init(progress: InstanceType<typeof ProgressBar>) {
     }
 
     progress.tick(10, {
-      message: `using starter for ${platformName}, validating config`,
+      message: `using starter for ${platformName} as the selected platform, validating config`,
     });
 
     // Choose a folder name. If no machineName is given, create one using the project name.

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ program
   )
   .option(
     '-s --starter <repository>',
-    'Git repository of the Emulsify starter you would like to use, such as the Emulsify Drupal theme: https://github.com/emulsify-ds/emulsify-drupal.git',
+    'Git repository of the Emulsify starter you would like to use, such as the Emulsify Drupal theme: https://github.com/emulsify-ds/emulsify-starter',
   )
   .option(
     '-c --checkout <commit/branch/tag>',

--- a/src/schemas/variant.json
+++ b/src/schemas/variant.json
@@ -7,7 +7,7 @@
     "platform": {
       "type": "string",
       "description": "Name of the variant, usually indicating the platform for which the variant is intended, such as WordPress, or Drupal9",
-      "enum": ["drupal"]
+      "enum": ["none", "drupal"]
     },
     "structureImplementations": {
       "type": "array",

--- a/src/types/_emulsifyProjectConfig.d.ts
+++ b/src/types/_emulsifyProjectConfig.d.ts
@@ -66,7 +66,7 @@ export interface EmulsifyProjectConfiguration {
     /**
      * Name of the variant, usually indicating the platform for which the variant is intended, such as WordPress, or Drupal9
      */
-    platform: 'drupal';
+    platform: 'none' | 'drupal';
     structureImplementations: StructureImplementations;
     /**
      * Git repository containing the system this project is utilizing

--- a/src/types/_system.d.ts
+++ b/src/types/_system.d.ts
@@ -119,7 +119,7 @@ export interface EmulsifySystem {
     /**
      * Name of the variant, usually indicating the platform for which the variant is intended, such as WordPress, or Drupal9
      */
-    platform: 'drupal';
+    platform: 'none' | 'drupal';
     structureImplementations: StructureImplementations;
     components: Components;
     directories?: Directories;

--- a/src/types/_variant.d.ts
+++ b/src/types/_variant.d.ts
@@ -8,7 +8,7 @@
 /**
  * Name of the variant, usually indicating the platform for which the variant is intended, such as WordPress, or Drupal9
  */
-export type Platform = 'drupal';
+export type Platform = 'none' | 'drupal';
 /**
  * Array containing an object for each structure specified in the system to which this variant belongs
  */

--- a/src/util/getAvailableStarters.test.ts
+++ b/src/util/getAvailableStarters.test.ts
@@ -9,7 +9,13 @@ describe('getAvailableStarters', () => {
         platform: 'none',
         platformMajorVersion: 1,
         repository: 'https://github.com/emulsify-ds/emulsify-starter',
-        checkout: 'develop',
+        checkout: 'main',
+      },
+      {
+        platform: 'drupal',
+        platformMajorVersion: 11,
+        repository: 'https://github.com/emulsify-ds/emulsify-drupal-starter',
+        checkout: 'main',
       },
     ];
 

--- a/src/util/getAvailableStarters.test.ts
+++ b/src/util/getAvailableStarters.test.ts
@@ -6,10 +6,10 @@ describe('getAvailableStarters', () => {
 
     const expected = [
       {
-        checkout: 'master',
-        platform: 'drupal',
-        platformMajorVersion: 9,
-        repository: 'https://github.com/emulsify-ds/emulsify-drupal.git',
+        platform: 'none',
+        platformMajorVersion: 1,
+        repository: 'https://github.com/emulsify-ds/emulsify-starter',
+        checkout: 'develop',
       },
     ];
 

--- a/src/util/getAvailableStarters.ts
+++ b/src/util/getAvailableStarters.ts
@@ -8,10 +8,10 @@ import type { EmulsifyStarter } from '@emulsify-cli/internal';
 export default function getAvailableStarters(): EmulsifyStarter[] {
   return [
     {
-      platform: 'drupal',
-      platformMajorVersion: 9,
-      repository: 'https://github.com/emulsify-ds/emulsify-drupal.git',
-      checkout: 'master',
+      platform: 'none',
+      platformMajorVersion: 1,
+      repository: 'https://github.com/emulsify-ds/emulsify-starter',
+      checkout: 'develop',
     },
   ];
 }

--- a/src/util/getAvailableStarters.ts
+++ b/src/util/getAvailableStarters.ts
@@ -11,7 +11,13 @@ export default function getAvailableStarters(): EmulsifyStarter[] {
       platform: 'none',
       platformMajorVersion: 1,
       repository: 'https://github.com/emulsify-ds/emulsify-starter',
-      checkout: 'develop',
+      checkout: 'main',
+    },
+    {
+      platform: 'drupal',
+      platformMajorVersion: 11,
+      repository: 'https://github.com/emulsify-ds/emulsify-drupal-starter',
+      checkout: 'main',
     },
   ];
 }

--- a/src/util/getGitRepoNameFromUrl.test.ts
+++ b/src/util/getGitRepoNameFromUrl.test.ts
@@ -12,9 +12,9 @@ describe('getGitRepoNameFromUrl', () => {
     expect.assertions(1);
     expect(
       getGitRepoNameFromUrl(
-        'https://github.com/emulsify-ds/emulsify-drupal.git',
+        'https://github.com/emulsify-ds/emulsify-starter.git',
       ),
-    ).toBe('emulsify-drupal');
+    ).toBe('emulsify-starter');
   });
 
   it('can throw an Error if given an invalid git url', () => {
@@ -23,7 +23,7 @@ describe('getGitRepoNameFromUrl', () => {
       getGitRepoNameFromUrl('');
     }).toThrow(Error);
     expect(() => {
-      getGitRepoNameFromUrl('https://github.com/emulsify-ds/emulsify-drupal');
+      getGitRepoNameFromUrl('https://github.com/emulsify-ds/emulsify-starter');
     }).toThrow(Error);
   });
 });

--- a/src/util/platform/getInitSuccessMessageForPlatform.ts
+++ b/src/util/platform/getInitSuccessMessageForPlatform.ts
@@ -14,7 +14,7 @@ export default function getInitSuccessMessageForPlatform(
   method: LogMethod;
   message: string;
 }[] {
-  if (platform === 'drupal') {
+  if (platform === 'none' || platform === 'drupal') {
     return [
       {
         method: 'info',

--- a/src/util/platform/getNoPlatformInfo.test.ts
+++ b/src/util/platform/getNoPlatformInfo.test.ts
@@ -1,0 +1,27 @@
+jest.mock('../fs/findFileInCurrentPath', () => jest.fn());
+jest.mock('../fs/loadJsonFile', () => jest.fn());
+
+import findFileInCurrentPath from '../fs/findFileInCurrentPath.js';
+import getNoPlatformInfo from './getNoPlatformInfo.js';
+
+const findFileMock = (findFileInCurrentPath as jest.Mock).mockReturnValue(
+  '/home/uname/Projects/cornflake/project.emulsify.json',
+);
+
+describe('getNoPlatformInfo', () => {
+  it('returns PlatformInstanceInfo if current directory is found', async () => {
+    expect.assertions(1);
+    await expect(getNoPlatformInfo()).resolves.toEqual({
+      name: 'none',
+      platformMajorVersion: 1,
+      emulsifyParentDirectory: '/home/uname/Projects/cornflake',
+      root: '/home/uname/Projects/cornflake/',
+    });
+  });
+
+  it('returns void if no project.emulsify.json file is found', async () => {
+    expect.assertions(1);
+    findFileMock.mockReturnValueOnce(undefined);
+    await expect(getNoPlatformInfo()).resolves.toBe(undefined);
+  });
+});

--- a/src/util/platform/getNoPlatformInfo.test.ts
+++ b/src/util/platform/getNoPlatformInfo.test.ts
@@ -14,14 +14,15 @@ describe('getNoPlatformInfo', () => {
     await expect(getNoPlatformInfo()).resolves.toEqual({
       name: 'none',
       platformMajorVersion: 1,
-      emulsifyParentDirectory: '/home/uname/Projects/cornflake',
-      root: '/home/uname/Projects/cornflake/',
+      emulsifyParentDirectory:
+        '/home/uname/Projects/cornflake/web/themes/custom',
+      root: '/home/uname/Projects/cornflake',
     });
   });
 
   it('returns void if no project.emulsify.json file is found', async () => {
     expect.assertions(1);
     findFileMock.mockReturnValueOnce(undefined);
-    await expect(getNoPlatformInfo()).resolves.toBe(undefined);
+    await expect(getNoPlatformInfo()).resolves.toBeUndefined();
   });
 });

--- a/src/util/platform/getNoPlatformInfo.ts
+++ b/src/util/platform/getNoPlatformInfo.ts
@@ -1,0 +1,24 @@
+import type { PlatformInstanceInfo } from '@emulsify-cli/internal';
+import { resolve } from 'path';
+import findFileInCurrentPath from '../fs/findFileInCurrentPath.js';
+import { resolveCurrentPath } from '../fs/resolveCurrentPath.js';
+
+/**
+ * Looks for no platform specified within the cwd, and returns information
+ * such as name, root path, and version.
+ */
+export default async function getNoPlatformInfo(): Promise<PlatformInstanceInfo | void> {
+  const existingProject = findFileInCurrentPath('project.emulsify.json');
+  if (!existingProject) {
+    return undefined;
+  }
+  const { directoryPath } = resolveCurrentPath();
+  const root = resolve(directoryPath);
+
+  return {
+    root,
+    name: 'none',
+    emulsifyParentDirectory: root,
+    platformMajorVersion: 1,
+  };
+}

--- a/src/util/platform/getNoPlatformInfo.ts
+++ b/src/util/platform/getNoPlatformInfo.ts
@@ -1,7 +1,6 @@
-import type { PlatformInstanceInfo } from '@emulsify-cli/internal';
-import { resolve } from 'path';
+import { dirname, join } from 'path';
 import findFileInCurrentPath from '../fs/findFileInCurrentPath.js';
-import { resolveCurrentPath } from '../fs/resolveCurrentPath.js';
+import type { PlatformInstanceInfo } from '@emulsify-cli/internal';
 
 /**
  * Looks for no platform specified within the cwd, and returns information
@@ -12,13 +11,11 @@ export default async function getNoPlatformInfo(): Promise<PlatformInstanceInfo 
   if (!existingProject) {
     return undefined;
   }
-  const { directoryPath } = resolveCurrentPath();
-  const root = resolve(directoryPath);
-
+  const root = dirname(existingProject);
   return {
     root,
     name: 'none',
-    emulsifyParentDirectory: root,
+    emulsifyParentDirectory: join(root, 'web', 'themes', 'custom'),
     platformMajorVersion: 1,
   };
 }

--- a/src/util/platform/getPlatformInfo.test.ts
+++ b/src/util/platform/getPlatformInfo.test.ts
@@ -9,20 +9,32 @@ describe('getPlatformInfo', () => {
     (getDrupalInfo as jest.Mock).mockResolvedValueOnce({
       name: 'drupal',
       root: '/home/uname/Projects/cornflake',
-      platformMajorVersion: 9,
+      platformMajorVersion: 11,
     });
 
     const expected = {
       name: 'drupal',
-      platformMajorVersion: 9,
+      platformMajorVersion: 11,
       root: '/home/uname/Projects/cornflake',
     };
 
     await expect(getPlatformInfo()).resolves.toEqual(expected);
   });
 
-  it('returns undefined if the user (cwd) is not within any detectable platform', async () => {
-    (getDrupalInfo as jest.Mock).mockReturnValueOnce(undefined);
-    await expect(getPlatformInfo()).resolves.toBe(undefined);
+  it('returns no platform info if the user (cwd) is not within any detectable platform', async () => {
+    expect.assertions(1);
+    (getDrupalInfo as jest.Mock).mockResolvedValueOnce({
+      name: 'none',
+      root: '/home/uname/Projects/cornflake',
+      platformMajorVersion: 1,
+    });
+
+    const expected = {
+      name: 'none',
+      platformMajorVersion: 1,
+      root: '/home/uname/Projects/cornflake',
+    };
+
+    await expect(getPlatformInfo()).resolves.toEqual(expected);
   });
 });

--- a/src/util/platform/getPlatformInfo.ts
+++ b/src/util/platform/getPlatformInfo.ts
@@ -1,7 +1,7 @@
 import type { PlatformInstanceInfo } from '@emulsify-cli/internal';
 
 import getDrupalInfo from './getDrupalInfo.js';
-import getNoPlatformInfo from './getNoPlatformInfo';
+import getNoPlatformInfo from './getNoPlatformInfo.js';
 
 /**
  * Returns information about the platform the user is currently within (cwd), if it

--- a/src/util/platform/getPlatformInfo.ts
+++ b/src/util/platform/getPlatformInfo.ts
@@ -1,6 +1,7 @@
 import type { PlatformInstanceInfo } from '@emulsify-cli/internal';
 
 import getDrupalInfo from './getDrupalInfo.js';
+import getNoPlatformInfo from './getNoPlatformInfo';
 
 /**
  * Returns information about the platform the user is currently within (cwd), if it
@@ -9,5 +10,7 @@ import getDrupalInfo from './getDrupalInfo.js';
 export default async function getPlatformInfo(): Promise<PlatformInstanceInfo | void> {
   // @TODO: add support for more platforms, such as wordpress.
   const drupal = await getDrupalInfo();
-  return drupal || undefined;
+  const noPlatform = await getNoPlatformInfo();
+  const platform = drupal ? drupal : noPlatform;
+  return platform;
 }

--- a/src/util/system/getAvailableSystems.test.ts
+++ b/src/util/system/getAvailableSystems.test.ts
@@ -7,12 +7,12 @@ describe('getAvailableSystems', () => {
       {
         name: 'compound',
         repository: 'https://github.com/emulsify-ds/compound.git',
-        platforms: ['drupal'],
+        platforms: ['none', 'drupal'],
       },
       {
         name: 'emulsify-ui-kit',
         repository: 'https://github.com/emulsify-ds/emulsify-ui-kit.git',
-        platforms: ['drupal'],
+        platforms: ['none', 'drupal'],
       },
     ]);
   });

--- a/src/util/system/getAvailableSystems.ts
+++ b/src/util/system/getAvailableSystems.ts
@@ -17,12 +17,12 @@ export default async function getAvailableSystems(): Promise<
     {
       name: 'compound',
       repository: 'https://github.com/emulsify-ds/compound.git',
-      platforms: ['drupal'],
+      platforms: ['none', 'drupal'],
     },
     {
       name: 'emulsify-ui-kit',
       repository: 'https://github.com/emulsify-ds/emulsify-ui-kit.git',
-      platforms: ['drupal'],
+      platforms: ['none', 'drupal'],
     },
   ];
 }


### PR DESCRIPTION
## Summary
Using `emulsify init --platform` or `emulsify init --platform none` should install the https://github.com/emulsify-ds/emulsify-starter repository.

### What existing problem does the pull request solve?

The existing `emulsify init` command uses `Emulsify Drupal` which is now a base theme for Drupal. This means it is no longer a starter and requires `drush` to create it's sub theme.

## Documentation update (required)

If this pull request requires a change to Emulsify documentation, those changes, updates, and/or new information must accompany this pull request.

## How to review this pull request
- [ ] run `nvm use 20`
- [ ] Clone this repo locally
- [ ] Go into the directory and change to this branch `git checkout platform-starters`
- [ ] Run `which emulsify`
- [ ] Go to the directory where Emulsify is currently installed on your local system - I.e. to the place where there is a symlink to emulsify. Something like this when you run `ls -la`:

```
lrwxr-xr-x  1 user  staff    47B Aug 29 22:06 emulsify -> ../lib/node_modules/@emulsify/cli/dist/index.js
```
- [ ] Run `npm link [path-to-cloned-repo]/emulsify-cli`
- [ ] Go to a temporary folder you can install an Emulsify starter for testing. Example: `~/Projects/tmp/`
- [ ] Create an Emulsify project `emulsify init test-project --platform none`
- [ ] Go into your new `test-project` directory and verify this starter was installed: https://github.com/emulsify-ds/emulsify-starter 
- [ ] Go back to your parent folder to generate another Emulsify project. Example `~/Project/tmp`
- [ ] Create an Emulsify project `emulsify init test-project --platform drupal`
- [ ] Go into your new `test-project` directory and verify this starter was installed: https://github.com/emulsify-ds/emulsify-drupal-starter 
