### PR TITLE
 feat: Switch from chalk to colorette for better compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/progress": "^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
-        "chalk": "^4.1.2",
+        "colorette": "^2.0.20",
         "commander": "^12.0.0",
         "consola": "^2.15.3",
         "cosmiconfig": "^9.0.0",
@@ -2653,6 +2653,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3020,6 +3021,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -3381,6 +3383,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3393,14 +3396,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
     },
     "node_modules/commander": {
       "version": "12.1.0",
@@ -4502,6 +4504,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15052,6 +15055,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/progress": "^2.0.5",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
-    "chalk": "^4.1.2",
+    "colorette": "^2.0.20",
     "commander": "^12.0.0",
     "consola": "^2.15.3",
     "cosmiconfig": "^9.0.0",

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -3,7 +3,7 @@
  * Exports methods that MUST be used when writing to the console.
  */
 
-import chalk from 'chalk';
+import { cyan, red, yellow, green, dim, bold } from 'colorette';
 import R from 'ramda';
 import consolaGlobalInstance, { Consola } from 'consola';
 
@@ -18,12 +18,12 @@ export type LogMethod =
 const logMethodColorMap: {
   [name in LogMethod]: (message: string) => string;
 } = {
-  info: chalk.cyan,
-  error: chalk.red.bold,
-  warn: chalk.yellow.bold,
-  debug: chalk.dim,
-  verbose: chalk.dim,
-  success: chalk.green,
+  info: cyan,
+  error: (message: string) => bold(red(message)),
+  warn: (message: string) => bold(yellow(message)),
+  debug: dim,
+  verbose: dim,
+  success: green,
 };
 
 const withColor =

--- a/src/util/platform/getInitSuccessMessageForPlatform.ts
+++ b/src/util/platform/getInitSuccessMessageForPlatform.ts
@@ -1,5 +1,5 @@
 import { LogMethod } from 'src/lib/log';
-import chalk from 'chalk';
+import { cyan } from 'colorette';
 
 /**
  * Returns the init success log messages for a given platform.
@@ -36,12 +36,12 @@ export default function getInitSuccessMessageForPlatform(
       {
         method: 'verbose',
         message: `
-            ${chalk.cyan('List systems')}: emulsify system list
-            ${chalk.cyan('Install a system')}: emulsify system install "system-name"
-            ${chalk.cyan(
+            ${cyan('List systems')}: emulsify system list
+            ${cyan('Install a system')}: emulsify system install "system-name"
+            ${cyan(
               'Install default system with default components',
             )}: emulsify system install compound
-            ${chalk.cyan(
+            ${cyan(
               'Install default system with all components',
             )}: emulsify system install compound --all
             `,


### PR DESCRIPTION
## Summary
Chalk 5 has issues with TypeScript and build tools. We’re switching to Colorette because it works better with our setup.