### PR TITLE
2.x Clean experimental warnings

### DIFF
--- a/jest.setup.cjs
+++ b/jest.setup.cjs
@@ -21,7 +21,7 @@ jest.mock('fs', () => ({
   promises: {
     writeFile: jest.fn(),
     readFile: jest.fn(),
-    rmdir: jest.fn(),
+    rm: jest.fn(),
     mkdir: jest.fn(),
     copyFile: jest.fn(),
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@emulsify/cli",
-  "version": "1.10.2",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@emulsify/cli",
-      "version": "1.10.2",
+      "version": "2.0.0",
       "license": "GPL-2.0",
       "dependencies": {
         "@types/progress": "^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
+        "boxen": "^8.0.1",
         "colorette": "^2.0.20",
         "commander": "^12.0.0",
         "consola": "^2.15.3",
@@ -2890,6 +2891,44 @@
         }
       }
     },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-align/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -3154,6 +3193,64 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/boxen": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+      "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^8.0.0",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.21.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/type-fest": {
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
+      "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3369,6 +3466,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-cursor": {
@@ -4178,7 +4287,6 @@
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/emojilib": {
@@ -4614,7 +4722,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
       "integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -15259,7 +15366,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^10.3.0",
@@ -15310,7 +15416,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -15323,7 +15428,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -16021,6 +16125,21 @@
         "node": ">= 8"
       }
     },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -16032,7 +16151,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
       "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
@@ -16101,7 +16219,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -16114,7 +16231,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -16127,7 +16243,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2918,7 +2918,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3672,7 +3671,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3685,7 +3683,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "npm run build-schema-types && npm run build-ts",
     "build-ts": "tsc --build tsconfig.dist.json",
-    "build-schema-types": "node --no-warnings=ExperimentalWarning --loader ts-node/esm ./src/scripts/jsonSchemaToTs.ts",
+    "build-schema-types": "node --import ./src/register.mjs ./src/scripts/jsonSchemaToTs.ts",
     "watch": "nodemon --watch src --ext ts,json --ignore src/types --exec npm run build",
     "watch-ts": "nodemon --watch src --ext ts,json --ignore src/types --exec npm run build-ts",
     "format": "prettier --write './src/**/*.{js,ts}'",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@emulsify/cli",
-  "version": "1.10.2",
+  "productName": "Emulsify CLI",
+  "version": "2.0.0",
   "description": "Command line interface for Emulsify",
   "repository": "git@github.com:emulsify-ds/emulsify-cli.git",
   "author": "Patrick Coffey <patrickcoffey48@gmail.com>",
@@ -61,6 +62,7 @@
     "@types/progress": "^2.0.5",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
+    "boxen": "^8.0.1",
     "colorette": "^2.0.20",
     "commander": "^12.0.0",
     "consola": "^2.15.3",

--- a/src/handlers/init.test.ts
+++ b/src/handlers/init.test.ts
@@ -20,7 +20,7 @@ import { EXIT_ERROR } from '../lib/constants.js';
 const root = '/home/uname/Projects/cornflake';
 
 const existsSyncMock = (fs.existsSync as jest.Mock).mockReturnValue(false);
-const rmdirMock = (fs.promises.rmdir as jest.Mock).mockReturnValue(true);
+const rmMock = (fs.promises.rm as jest.Mock).mockReturnValue(true);
 const gitCloneMock = git().clone as jest.Mock;
 const getPlatformInfoMock = (getPlatformInfo as jest.Mock).mockReturnValue({
   root,
@@ -73,7 +73,7 @@ describe('init', () => {
       '/home/uname/Projects/cornflake/cornflake',
       { '--branch': 'main' },
     );
-    expect(rmdirMock).toHaveBeenCalledWith(
+    expect(rmMock).toHaveBeenCalledWith(
       '/home/uname/Projects/cornflake/cornflake/.git',
       { recursive: true },
     );

--- a/src/handlers/init.ts
+++ b/src/handlers/init.ts
@@ -193,7 +193,7 @@ export default function init(progress: InstanceType<typeof ProgressBar>) {
       // Remove the .git directory, as this is a starter kit. This step
       // should happen after dependencies are installed, and init scripts are
       // executed, otherwise git-reliant dev deps in the starter may error out.
-      await fs.rmdir(join(target, '.git'), { recursive: true });
+      await fs.rm(join(target, '.git'), { recursive: true });
 
       progress.tick(10, {
         message: 'init script executed, initialization complete',

--- a/src/handlers/systemInstall.ts
+++ b/src/handlers/systemInstall.ts
@@ -7,6 +7,7 @@ import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import { join } from 'path';
 import { existsSync } from 'fs';
+import { createRequire } from 'module';
 import {
   EXIT_ERROR,
   EXIT_SUCCESS,
@@ -27,8 +28,9 @@ import setEmulsifyConfig from '../util/project/setEmulsifyConfig.js';
 import getEmulsifyConfig from '../util/project/getEmulsifyConfig.js';
 import findFileInCurrentPath from '../util/fs/findFileInCurrentPath.js';
 import executeScript from '../util/fs/executeScript.js';
-import systemSchema from '../schemas/system.json' with { type: 'json' };
-import variantSchema from '../schemas/variant.json' with { type: 'json' };
+
+const systemSchema = createRequire(import.meta.url)('../schemas/system.json');
+const variantSchema = createRequire(import.meta.url)('../schemas/variant.json');
 
 /**
  * Helper function that uses InstallSystemHandlerOptions input to determine what

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,11 @@ import systemList from './handlers/systemList.js';
 import systemInstall from './handlers/systemInstall.js';
 import componentList from './handlers/componentList.js';
 import componentInstall from './handlers/componentInstall.js';
+import { createRequire } from 'module';
+import { cyan, green } from 'colorette';
+import boxen from 'boxen';
+
+const packageInfo = createRequire(import.meta.url)('../package.json');
 
 // Main program commands.
 program
@@ -99,6 +104,27 @@ component
   .alias('i')
   .action(componentInstall);
 
-// This doesn't seem to be used for anything.
-program.version('2');
+/*
+ * Generate a styled version message using boxen and colorette.
+ * This displays the product name and version in a visually appealing format.
+ *
+ *  ╭ Emulsify CLI ──────╮
+ *  │                    │
+ *  │   Version: 2.0.0   │
+ *  │                    │
+ *  ╰────────────────────╯
+ */
+const title = cyan(packageInfo.productName);
+const message = `Version: ${green(packageInfo.version)}`;
+
+const boxedMessage = boxen(message, {
+  title: title,
+  backgroundColor: 'black',
+  borderStyle: 'round',
+  borderColor: 'blue',
+  padding: 1,
+  margin: 1,
+});
+
+program.version(boxedMessage);
 void program.parseAsync(process.argv);

--- a/src/register.mjs
+++ b/src/register.mjs
@@ -1,0 +1,5 @@
+import { register } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+// Register the TypeScript loader for ESM
+register('ts-node/esm', pathToFileURL('./'));


### PR DESCRIPTION
## Summary

The emulsify-cli commands should now run without displaying experimental warnings.

<!-- Summary of the PR -->

This PR addresses the following issues/features:

- Replaces deprecated fs.rmdir with fs.rm.
- Cleans up experimental warnings.
- Implements a custom TypeScript loader.
- Updates version to 2.0.0 and enhances the display for the version command.

## How to review this pull request
- [ ] Switch to this branch using git checkout 2.x-clean-experimental-warnings.
- [ ] Run npm run build.
- [ ] Navigate to the Drupal test project and run emulsify init test-project --platform drupal ./.
- [ ] Ensure the emulsify project starts without any console warnings.

<img width="1118" alt="Captura de pantalla 2024-09-30 a la(s) 4 44 08 p  m" src="https://github.com/user-attachments/assets/8f8ff9b0-fe14-473a-bf2c-a4d6fc213e6c">