### PR TITLE
chore: match version number in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@emulsify/cli",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@emulsify/cli",
-      "version": "1.10.2",
+      "version": "1.11.0",
       "license": "GPL-2.0",
       "dependencies": {
         "@types/progress": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulsify/cli",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "description": "Command line interface for Emulsify",
   "repository": "git@github.com:emulsify-ds/emulsify-cli.git",
   "author": "Patrick Coffey <patrickcoffey48@gmail.com>",


### PR DESCRIPTION
## Summary
- Official release 1.11.0 is not reflected in package.json