### PR TITLE
Fix for broken tag installs

### DIFF
--- a/src/util/cache/cloneIntoCache.test.ts
+++ b/src/util/cache/cloneIntoCache.test.ts
@@ -40,7 +40,7 @@ describe('cloneIntoCache', () => {
     existsSyncMock.mockReturnValueOnce(false).mockReturnValueOnce(false);
     await cloneIntoCache('systems', ['cornflake'])(cloneOptions);
     expect(mkdirMock).toHaveBeenCalledWith(
-      'home/uname/.emulsify/cache/systems/2a39785f5c873d7a694ac505a8123bb9',
+      'home/uname/.emulsify/cache/systems/6ce9bab2a26010442d0708dc5ec76cf7',
       {
         recursive: true,
       },
@@ -53,7 +53,7 @@ describe('cloneIntoCache', () => {
     await cloneIntoCache('systems', ['cornflake'])(cloneOptions);
     expect(gitCloneMock).toHaveBeenCalledWith(
       'repo-path',
-      'home/uname/.emulsify/cache/systems/2a39785f5c873d7a694ac505a8123bb9/cornflake',
+      'home/uname/.emulsify/cache/systems/6ce9bab2a26010442d0708dc5ec76cf7/cornflake',
       { '--branch': 'branch-name' },
     );
   });

--- a/src/util/cache/cloneIntoCache.ts
+++ b/src/util/cache/cloneIntoCache.ts
@@ -20,7 +20,7 @@ export default function cloneIntoCache(
   itemPath: CacheItemPath,
 ) {
   return async ({ repository, checkout }: GitCloneOptions): Promise<void> => {
-    const destination = getCachedItemPath(bucket, itemPath, checkout);
+    const destination = getCachedItemPath(bucket, itemPath);
     const parentDir = dirname(destination);
 
     // If the item is already in cache, simply return.


### PR DESCRIPTION
## Summary

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

- Bug: Can't install Emulsify UI Kit because it uses a tag.

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

We are only factoring in the tag/branch/commit hash during the initial clone of the system and then never again. For now we'll remove this to avoid issues on install.

## How to review this pull request
<!-- Provide step-by-step instructions to functionally test this PR. -->
<!-- Ensure that your code passing the repo's linting standards. -->
- [ ] Pull this code
- [ ] npm run build
- [ ] npm link
- [ ] Take note of your node version
- [ ] Move to a drupal directory and emulsify init and then attempt to install a system like emulsify-ui-kit
- [ ] Should install without issue.

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Closes #
