### PR TITLE
Fix: Caching rotation bug and system install with tags

### DIFF
--- a/src/handlers/systemInstall.ts
+++ b/src/handlers/systemInstall.ts
@@ -118,16 +118,15 @@ export default async function systemInstall(
     );
   }
 
-  let checkout = repo.checkout;
   // Attempt to get latest tag if no branch was supplied.
-  if (!checkout) {
-    checkout = await getRepositoryLatestTag(repo.repository);
+  if (repo.checkout === undefined) {
+    repo.checkout = await getRepositoryLatestTag(repo.repository);
   }
 
   // Clone the system into the cache.
   await cloneIntoCache('systems', [repo.name])({
     repository: repo.repository,
-    checkout: checkout,
+    checkout: repo.checkout,
   });
 
   // Load the system configuration file.

--- a/src/util/cache/copyItemFromCache.test.ts
+++ b/src/util/cache/copyItemFromCache.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
 jest.mock('./getCachedItemPath', () =>
   jest.fn(
     () =>
@@ -5,9 +6,24 @@ jest.mock('./getCachedItemPath', () =>
   ),
 );
 import { copy, remove } from 'fs-extra';
+import getEmulsifyConfig from '../project/getEmulsifyConfig';
 import copyItemFromCache from './copyItemFromCache';
 
+// Mock the getEmulsifyConfig function
+jest.mock('../project/getEmulsifyConfig', () => jest.fn());
+
 describe('copyItemFromCache', () => {
+  const mockConfig = {
+    system: {
+      checkout: 'checkoutBranch',
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getEmulsifyConfig as jest.Mock).mockResolvedValue(mockConfig); // Ensure proper casting
+  });
+
   it('can copy an item from cache to the given destination', async () => {
     await copyItemFromCache(
       'systems',
@@ -19,6 +35,7 @@ describe('copyItemFromCache', () => {
       '/home/uname/Projects/drupal/web/themes/custom/cornflake/components/00-base/colors',
     );
   });
+
   it('can remove a destination before copying items from the cache if "force" is true', async () => {
     await copyItemFromCache(
       'systems',
@@ -27,6 +44,36 @@ describe('copyItemFromCache', () => {
       true,
     );
     expect(remove).toHaveBeenCalledWith(
+      '/home/uname/Projects/drupal/web/themes/custom/cornflake/components/00-base/colors',
+    );
+  });
+
+  it('should handle missing emulsifyConfig system checkout', async () => {
+    (getEmulsifyConfig as jest.Mock).mockResolvedValue({ system: {} });
+
+    await copyItemFromCache(
+      'systems',
+      ['compound', 'components', '00-base', 'colors'],
+      '/home/uname/Projects/drupal/web/themes/custom/cornflake/components/00-base/colors',
+    );
+
+    expect(copy).toHaveBeenCalledWith(
+      '/home/uname/.emulsify/cache/systems/12345/compound/components/00-base/colors',
+      '/home/uname/Projects/drupal/web/themes/custom/cornflake/components/00-base/colors',
+    );
+  });
+
+  it('should handle undefined emulsifyConfig', async () => {
+    (getEmulsifyConfig as jest.Mock).mockResolvedValue(undefined);
+
+    await copyItemFromCache(
+      'systems',
+      ['compound', 'components', '00-base', 'colors'],
+      '/home/uname/Projects/drupal/web/themes/custom/cornflake/components/00-base/colors',
+    );
+
+    expect(copy).toHaveBeenCalledWith(
+      '/home/uname/.emulsify/cache/systems/12345/compound/components/00-base/colors',
       '/home/uname/Projects/drupal/web/themes/custom/cornflake/components/00-base/colors',
     );
   });

--- a/src/util/cache/copyItemFromCache.ts
+++ b/src/util/cache/copyItemFromCache.ts
@@ -1,6 +1,7 @@
 import type { CacheBucket, CacheItemPath } from '@emulsify-cli/cache';
 import { copy, remove } from 'fs-extra';
 import getCachedItemPath from './getCachedItemPath';
+import getEmulsifyConfig from '../project/getEmulsifyConfig';
 
 /**
  * Accepts a cache bucket, item path, and item name, and copies the cached item to the
@@ -18,7 +19,17 @@ export default async function copyFileFromCache(
   destination: string,
   force = false,
 ): Promise<void> {
-  const source = getCachedItemPath(bucket, itemPath);
+  // Get the existing checkout setting if we have it and use it.
+  const emulsifyConfig = await getEmulsifyConfig();
+  let checkout = '';
+  if (
+    emulsifyConfig != undefined &&
+    emulsifyConfig.system &&
+    emulsifyConfig.system.checkout
+  ) {
+    checkout = emulsifyConfig.system.checkout;
+  }
+  const source = getCachedItemPath(bucket, itemPath, checkout);
 
   if (force) {
     await remove(destination);


### PR DESCRIPTION
## Summary
Backporting fixes from the 2.x branch...
- CLI juggles the cache hashes and looses track of where things are stored locally. This can cause systems and components to fail during install
- Resolve an issue where an emulsify system with release tags causes json validation errors due to the `repo.checkout` never being properly set.