### PR TITLE
release: init wizard and improved cli help

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ npm install -g @emulsify/cli
 Run the current command help at any time:
 
 ```bash
+emulsify
 emulsify --help
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ Create a Drupal starter project, install a system, and add components:
 ```bash
 emulsify init "My Theme" ./web/themes/custom --platform drupal
 cd ./web/themes/custom/my_theme
-emulsify system list
-emulsify system install compound
+emulsify system install
 emulsify component list
 emulsify component install card
 emulsify component create promo-card --directory molecules --format default
@@ -41,6 +40,7 @@ For non-interactive environments, pass the flags that normally prompt for input:
 
 ```bash
 emulsify init "My Theme" ./web/themes/custom --platform drupal --yes
+emulsify system install compound
 emulsify component create promo-card --directory molecules --format default --yes
 ```
 
@@ -66,7 +66,7 @@ Detailed documentation lives in [docs](./docs/README.md).
 | ----------------------------------- | ----------------------------- | ----------------------------------------------------------------- |
 | `emulsify init [name] [path]`       |                               | Initializes an Emulsify project from a starter.                   |
 | `emulsify system list`              | `emulsify system ls`          | Lists built-in systems available for installation.                |
-| `emulsify system install [name]`    |                               | Installs a system in the current Emulsify project.                |
+| `emulsify system install [name]`    |                               | Installs or scaffolds a system in the current Emulsify project.   |
 | `emulsify component list`           | `emulsify component ls`       | Lists components available from the installed system and variant. |
 | `emulsify component install [name]` | `emulsify component i [name]` | Installs one component from the installed system and variant.     |
 | `emulsify component create [name]`  | `emulsify component c [name]` | Creates a local component in the current Emulsify project.        |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -3,6 +3,7 @@
 Emulsify CLI installs as the `emulsify` binary.
 
 ```bash
+emulsify
 emulsify --help
 emulsify <command> --help
 ```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -15,7 +15,7 @@ The examples below reflect the command definitions in `src/index.ts` and the gen
 | ----------------------------------- | ----------------------------- | ---------------------------------------------------------------- |
 | `emulsify init [name] [path]`       |                               | Initialize an Emulsify project from a starter.                   |
 | `emulsify system list`              | `emulsify system ls`          | List built-in systems available for installation.                |
-| `emulsify system install [name]`    |                               | Install a system in the current Emulsify project.                |
+| `emulsify system install [name]`    |                               | Install or scaffold a system in the current Emulsify project.    |
 | `emulsify component list`           | `emulsify component ls`       | List components available from the installed system and variant. |
 | `emulsify component install [name]` | `emulsify component i [name]` | Install a component from the installed system and variant.       |
 | `emulsify component create [name]`  | `emulsify component c [name]` | Generate a new local component in the current project.           |
@@ -33,8 +33,10 @@ Options:
 | `-m, --machineName <machineName>`    | Machine-friendly project folder and config name. If omitted, the CLI derives it from the project name. Drupal machine names use underscores.   |
 | `-s, --starter <repository>`         | Starter Git repository to clone.                                                                                                               |
 | `-c, --checkout <commit/branch/tag>` | Starter commit, branch, or tag to check out after clone.                                                                                       |
-| `-p, --platform <platform>`          | Platform to use when auto-detection is unavailable or should be overridden. Built-in starters are currently available for `none` and `drupal`. |
+| `-p, --platform <platform>`          | Platform to use when auto-detection is unavailable or should be overridden. Built-in starters are currently available for `drupal` and `none`. |
 | `-y, --yes`                          | Accept default values for missing init options without prompting.                                                                              |
+
+When `--platform` is not provided and the platform cannot be detected, interactive terminals prompt with `drupal` and `none`.
 
 Examples:
 
@@ -60,6 +62,16 @@ Lists the built-in system names and repositories known to this CLI version.
 emulsify system install [name]
 ```
 
+Run without `[name]` in an interactive terminal to choose from built-in systems, scaffold a new system definition, or cancel:
+
+```text
+? Choose a component system:
+❯ compound
+  emulsify-ui-kit
+  create a new system
+  cancel
+```
+
 Options:
 
 | Option                               | Description                                                                                                                                      |
@@ -71,10 +83,14 @@ Options:
 Examples:
 
 ```bash
+emulsify system install
 emulsify system install compound
+emulsify system install emulsify-ui-kit
 emulsify system install compound --all
 emulsify system install --repository https://github.com/example/example-system.git --checkout v1.0.0
 ```
+
+Selecting `create a new system` writes `system.emulsify.json` in the current Emulsify project root. Complete the generated system name, repository, structures, variants, and components before using it to install or generate components.
 
 ## `component list`
 

--- a/docs/project-initialization.md
+++ b/docs/project-initialization.md
@@ -38,24 +38,27 @@ You can override starter resolution with `--starter` and `--checkout`.
 ## Interactive Output
 
 Interactive init asks for missing values, then prints compact next steps.
+When init detects that it is running inside a Drupal project, it also reminds you to install the required Drupal Composer packages.
 
 ```text
 ✔ Project name: britty
-✔ Target directory: ./
-✔ Platform: drupal
 [====================] 100% initialization complete
 
 Created an Emulsify project in britty.
 
-Install the Drupal integration module:
-  composer require drupal/emulsify_tools
+Detected a Drupal project.
+
+Install the required Drupal packages with Composer:
+  composer require drupal/emulsify drupal/emulsify_tools
   drush en emulsify_tools -y
+
+The generated Drupal starter uses drupal/emulsify as its base theme and emulsify_tools for Drupal integration, so both packages must exist in the Drupal codebase.
 
 Next, choose a component system:
   emulsify system install
 ```
 
-For platform `none`, the Drupal integration module reminder is omitted:
+For platform `none`, or when `drupal` is selected manually outside a detected Drupal project, the Drupal package reminder is omitted:
 
 ```text
 Next, choose a component system:

--- a/docs/project-initialization.md
+++ b/docs/project-initialization.md
@@ -18,6 +18,14 @@ The CLI tries to determine the platform from the current working directory befor
 | Existing Emulsify project found by `project.emulsify.json`              | Platform `none`, target parent `<project-root>/web/themes/custom`.                      |
 | No detectable platform                                                  | Use `--platform`, prompt in an interactive terminal, or use `--yes` to accept defaults. |
 
+When the platform cannot be detected and stdin is a TTY, the prompt choices are:
+
+```text
+? Platform:
+❯ drupal
+  none
+```
+
 Built-in starter repositories:
 
 | Platform | Repository                                               | Checkout |
@@ -26,6 +34,37 @@ Built-in starter repositories:
 | `drupal` | `https://github.com/emulsify-ds/emulsify-drupal-starter` | `main`   |
 
 You can override starter resolution with `--starter` and `--checkout`.
+
+## Interactive Output
+
+Interactive init asks for missing values, then prints compact next steps.
+
+```text
+✔ Project name: britty
+✔ Target directory: ./
+✔ Platform: drupal
+[====================] 100% initialization complete
+
+  __
+ /  \
+ \__/
+
+Created an Emulsify project in britty.
+
+Install the Drupal integration module:
+  composer require drupal/emulsify_tools
+  drush en emulsify_tools -y
+
+Next, choose a component system:
+  emulsify system install
+```
+
+For platform `none`, the Drupal integration module reminder is omitted:
+
+```text
+Next, choose a component system:
+  emulsify system install
+```
 
 ## Target Directory
 
@@ -87,6 +126,8 @@ With `--yes`, missing values use the current defaults:
 | Platform      | `drupal`        |
 
 Explicit arguments and flags still take precedence over `--yes` defaults.
+
+In non-interactive mode, provide `--platform drupal` or `--platform none` when auto-detection is unavailable.
 
 ## Custom Starter
 

--- a/docs/project-initialization.md
+++ b/docs/project-initialization.md
@@ -45,10 +45,6 @@ Interactive init asks for missing values, then prints compact next steps.
 ✔ Platform: drupal
 [====================] 100% initialization complete
 
-  __
- /  \
- \__/
-
 Created an Emulsify project in britty.
 
 Install the Drupal integration module:

--- a/docs/systems.md
+++ b/docs/systems.md
@@ -18,15 +18,31 @@ Built-in systems in this CLI version:
 
 The list is currently hard-coded in the CLI. Future versions may resolve systems from a registry. Installation still depends on the variants defined by the selected system's `system.emulsify.json`.
 
-## Install A Built-In System
+## Install A System
 
 Run `system install` from inside an Emulsify project.
 
 ```bash
-emulsify system install compound
+emulsify system install
 ```
 
-The command:
+In an interactive terminal, the CLI prompts for a system:
+
+```text
+? Choose a component system:
+❯ compound
+  emulsify-ui-kit
+  create a new system
+  cancel
+```
+
+Choosing `compound` or `emulsify-ui-kit` installs that built-in system. Choosing `cancel` exits without changing files:
+
+```text
+System install cancelled.
+```
+
+For a built-in system, the command:
 
 1. Finds and validates the nearest `project.emulsify.json`.
 2. Resolves the named system repository.
@@ -37,6 +53,13 @@ The command:
 7. Writes `system` and `variant` entries into `project.emulsify.json`.
 8. Installs components marked `required: true`.
 9. Installs variant-level general files and directories.
+
+If you already know the system name, pass it directly:
+
+```bash
+emulsify system install compound
+emulsify system install emulsify-ui-kit
+```
 
 Use `--all` to install every component in the selected variant during system installation:
 
@@ -57,6 +80,48 @@ emulsify system install \
 Custom system repository URLs must end in `.git`, because the CLI parses the system name from the repository filename.
 
 Prefer tags or commit hashes for `--checkout` so subsequent installs use the same system version.
+
+## Create A New System Definition
+
+Choose `create a new system` from the interactive prompt to scaffold a local `system.emulsify.json` in the current Emulsify project root.
+
+```text
+Created system.emulsify.json.
+
+Add your real system name, repository, structures, variants, and components before using this system to install or generate components.
+```
+
+The scaffold is intentionally minimal and must be completed before it represents a real component system:
+
+```json
+{
+  "name": "custom-system",
+  "homepage": "https://example.com/custom-system",
+  "repository": "https://github.com/example/custom-system.git",
+  "structure": [
+    {
+      "name": "components",
+      "description": "Project component library"
+    }
+  ],
+  "variants": [
+    {
+      "platform": "drupal",
+      "structureImplementations": [
+        {
+          "name": "components",
+          "directory": "./src/components"
+        }
+      ],
+      "components": []
+    }
+  ]
+}
+```
+
+The generated variant platform follows the current project platform when it is `drupal` or `none`. If `system.emulsify.json` already exists, the CLI stops rather than overwrite it.
+
+Creating a new system definition does not clone a remote system, install components, install general assets, run install hooks, or update `project.emulsify.json`.
 
 ## Project Config After Install
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@semantic-release/release-notes-generator": "^14.1.1",
         "@types/fs-extra": "^11.0.4",
         "@types/jest": "^30.0.0",
-        "@types/node": "^25.9.3",
+        "@types/node": "^26.0.0",
         "@types/progress": "^2.0.7",
         "husky": "^9.1.7",
         "jest": "^30.4.2",
@@ -2841,13 +2841,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -12035,9 +12035,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "devOptional": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@emulsify/cli",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@emulsify/cli",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "license": "GPL-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@emulsify/cli",
   "productName": "Emulsify CLI",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Command line interface for Emulsify",
   "repository": "git@github.com:emulsify-ds/emulsify-cli.git",
   "author": "Patrick Coffey <patrickcoffey48@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@semantic-release/release-notes-generator": "^14.1.1",
     "@types/fs-extra": "^11.0.4",
     "@types/jest": "^30.0.0",
-    "@types/node": "^25.9.3",
+    "@types/node": "^26.0.0",
     "@types/progress": "^2.0.7",
     "husky": "^9.1.7",
     "jest": "^30.4.2",

--- a/src/handlers/init.test.ts
+++ b/src/handlers/init.test.ts
@@ -196,6 +196,22 @@ describe('init', () => {
     );
   });
 
+  it('clones a custom starter without a checkout so Git uses the repository default branch', async () => {
+    expect.assertions(1);
+    getPlatformInfoMock.mockReturnValueOnce(undefined);
+
+    await init(progress)('cornflake', `${root}`, {
+      starter: 'git@github.com:example/custom-starter.git',
+      platform: 'drupal',
+    });
+
+    expect(gitCloneMock).toHaveBeenCalledWith(
+      'git@github.com:example/custom-starter.git',
+      '/home/uname/Projects/cornflake/cornflake',
+      {},
+    );
+  });
+
   it('uses flag-provided values without prompting in non-interactive mode', async () => {
     expect.assertions(5);
     getPlatformInfoMock.mockReturnValueOnce(undefined);
@@ -211,7 +227,7 @@ describe('init', () => {
     expect(gitCloneMock).toHaveBeenCalledWith(
       'https://github.com/emulsify-ds/emulsify-starter',
       '/home/uname/Projects/cornflake/cornflake',
-      { '--branch': 'main' },
+      {},
     );
     expect(writeJsonFileMock).toHaveBeenCalledWith(
       '/home/uname/Projects/cornflake/cornflake/project.emulsify.json',
@@ -282,7 +298,7 @@ describe('init', () => {
     expect(gitCloneMock).toHaveBeenCalledWith(
       'https://github.com/emulsify-ds/emulsify-starter',
       'emulsifytheme',
-      { '--branch': 'main' },
+      {},
     );
     expect(writeJsonFileMock).toHaveBeenCalledWith(
       'emulsifytheme/project.emulsify.json',

--- a/src/handlers/init.test.ts
+++ b/src/handlers/init.test.ts
@@ -139,7 +139,7 @@ describe('init', () => {
       '/home/uname/Projects/cornflake/cornflake',
       { '--branch': 'main' },
     );
-    expect(logMock).toHaveBeenCalledTimes(3);
+    expect(logMock).toHaveBeenCalledTimes(2);
     expect(logMock).toHaveBeenNthCalledWith(
       1,
       'success',

--- a/src/handlers/init.test.ts
+++ b/src/handlers/init.test.ts
@@ -36,6 +36,10 @@ const progress = progressMock as unknown as InstanceType<typeof ProgressBar>;
 const inputMock = input as jest.Mock;
 const selectMock = select as jest.Mock;
 const originalStdinIsTTY = process.stdin.isTTY;
+const systemSelectionMessage = [
+  'Next, choose a component system:',
+  '  emulsify system install',
+].join('\n');
 
 function setStdinIsTTY(value: boolean | undefined) {
   Object.defineProperty(process.stdin, 'isTTY', {
@@ -106,6 +110,37 @@ describe('init', () => {
     );
   });
 
+  it('logs Drupal Composer guidance when Drupal is auto-detected', async () => {
+    expect.assertions(4);
+    getPlatformInfoMock.mockReturnValueOnce({
+      root: `${root}/web`,
+      name: 'drupal',
+      emulsifyParentDirectory: `${root}/web/themes/custom`,
+      platformMajorVersion: 11,
+    });
+
+    await init(progress)('cornflake');
+
+    expect(gitCloneMock).toHaveBeenCalledWith(
+      'https://github.com/emulsify-ds/emulsify-drupal-starter',
+      '/home/uname/Projects/cornflake/web/themes/custom/cornflake',
+      { '--branch': 'main' },
+    );
+    expect(logMock).toHaveBeenCalledWith(
+      'warn',
+      expect.stringContaining(
+        'composer require drupal/emulsify drupal/emulsify_tools',
+      ),
+    );
+    expect(logMock).toHaveBeenCalledWith(
+      'warn',
+      expect.stringContaining(
+        'drupal/emulsify as its base theme and emulsify_tools for Drupal integration',
+      ),
+    );
+    expect(logMock).toHaveBeenCalledWith('info', systemSelectionMessage);
+  });
+
   it('uses the progress obj to display information on the init process', async () => {
     expect.assertions(5);
     await init(progress)('cornflake');
@@ -162,7 +197,7 @@ describe('init', () => {
   });
 
   it('uses flag-provided values without prompting in non-interactive mode', async () => {
-    expect.assertions(4);
+    expect.assertions(5);
     getPlatformInfoMock.mockReturnValueOnce(undefined);
 
     await init(progress)(undefined, root, {
@@ -191,10 +226,14 @@ describe('init', () => {
         },
       },
     );
+    expect(logMock).not.toHaveBeenCalledWith(
+      'warn',
+      expect.stringContaining('composer require drupal/emulsify'),
+    );
   });
 
   it('prompts for the platform with drupal and none choices when missing in an interactive terminal', async () => {
-    expect.assertions(4);
+    expect.assertions(5);
     setStdinIsTTY(true);
     getPlatformInfoMock.mockReturnValueOnce(undefined);
     selectMock.mockResolvedValueOnce('none');
@@ -222,6 +261,10 @@ describe('init', () => {
           repository: 'https://github.com/emulsify-ds/emulsify-starter',
         },
       },
+    );
+    expect(logMock).not.toHaveBeenCalledWith(
+      'warn',
+      expect.stringContaining('composer require drupal/emulsify'),
     );
   });
 
@@ -342,5 +385,9 @@ describe('init', () => {
       default: 'drupal',
     });
     expect(gitCloneMock).toHaveBeenCalled();
+    expect(logMock).not.toHaveBeenCalledWith(
+      'warn',
+      expect.stringContaining('composer require drupal/emulsify'),
+    );
   });
 });

--- a/src/handlers/init.test.ts
+++ b/src/handlers/init.test.ts
@@ -129,7 +129,7 @@ describe('init', () => {
   });
 
   it('can clone an Emulsify starter based on CLI input, and log a success message upon completion', async () => {
-    expect.assertions(2);
+    expect.assertions(3);
     await init(progress)('cornflake', `${root}`, {
       starter: 'https://github.com/emulsify-ds/emulsify-starter',
       checkout: 'main',
@@ -139,7 +139,12 @@ describe('init', () => {
       '/home/uname/Projects/cornflake/cornflake',
       { '--branch': 'main' },
     );
-    expect(logMock).toHaveBeenCalledTimes(5);
+    expect(logMock).toHaveBeenCalledTimes(3);
+    expect(logMock).toHaveBeenNthCalledWith(
+      1,
+      'success',
+      'Created an Emulsify project in /home/uname/Projects/cornflake/cornflake.',
+    );
   });
 
   it('can clone an Emulsify starter without a provided checkout', async () => {

--- a/src/handlers/init.test.ts
+++ b/src/handlers/init.test.ts
@@ -8,7 +8,7 @@ jest.mock('@inquirer/prompts');
 import fs from 'fs';
 import { simpleGit as git } from 'simple-git';
 import log from '../lib/log.js';
-import { input } from '@inquirer/prompts';
+import { input, select } from '@inquirer/prompts';
 import ProgressBar from 'progress';
 import installDependencies from '../util/project/installDependencies.js';
 import getPlatformInfo from '../util/platform/getPlatformInfo.js';
@@ -34,6 +34,7 @@ const progressMock = {
 };
 const progress = progressMock as unknown as InstanceType<typeof ProgressBar>;
 const inputMock = input as jest.Mock;
+const selectMock = select as jest.Mock;
 const originalStdinIsTTY = process.stdin.isTTY;
 
 function setStdinIsTTY(value: boolean | undefined) {
@@ -47,8 +48,10 @@ describe('init', () => {
   beforeEach(() => {
     logMock.mockClear();
     gitCloneMock.mockClear();
+    writeJsonFileMock.mockClear();
     progressMock.tick.mockClear();
     inputMock.mockClear();
+    selectMock.mockClear();
     setStdinIsTTY(false);
   });
 
@@ -76,8 +79,9 @@ describe('init', () => {
   });
 
   it('can detect the platform, and use information about the platform to autodetect the target directory and Emulsify starter', async () => {
-    expect.assertions(3);
+    expect.assertions(4);
     await init(progress)('cornflake');
+    expect(selectMock).not.toHaveBeenCalled();
     expect(gitCloneMock).toHaveBeenCalledWith(
       'https://github.com/emulsify-ds/emulsify-starter',
       '/home/uname/Projects/cornflake/cornflake',
@@ -153,7 +157,7 @@ describe('init', () => {
   });
 
   it('uses flag-provided values without prompting in non-interactive mode', async () => {
-    expect.assertions(3);
+    expect.assertions(4);
     getPlatformInfoMock.mockReturnValueOnce(undefined);
 
     await init(progress)(undefined, root, {
@@ -163,6 +167,7 @@ describe('init', () => {
     });
 
     expect(inputMock).not.toHaveBeenCalled();
+    expect(selectMock).not.toHaveBeenCalled();
     expect(gitCloneMock).toHaveBeenCalledWith(
       'https://github.com/emulsify-ds/emulsify-starter',
       '/home/uname/Projects/cornflake/cornflake',
@@ -183,8 +188,40 @@ describe('init', () => {
     );
   });
 
+  it('prompts for the platform with drupal and none choices when missing in an interactive terminal', async () => {
+    expect.assertions(4);
+    setStdinIsTTY(true);
+    getPlatformInfoMock.mockReturnValueOnce(undefined);
+    selectMock.mockResolvedValueOnce('none');
+
+    await init(progress)('cornflake', root, {
+      starter: 'https://github.com/emulsify-ds/emulsify-starter',
+    });
+
+    expect(inputMock).not.toHaveBeenCalled();
+    expect(selectMock).toHaveBeenCalledTimes(1);
+    expect(selectMock).toHaveBeenNthCalledWith(1, {
+      message: 'Platform:',
+      choices: ['drupal', 'none'],
+      default: 'drupal',
+    });
+    expect(writeJsonFileMock).toHaveBeenCalledWith(
+      '/home/uname/Projects/cornflake/cornflake/project.emulsify.json',
+      {
+        project: {
+          platform: 'none',
+          machineName: 'cornflake',
+          name: 'cornflake',
+        },
+        starter: {
+          repository: 'https://github.com/emulsify-ds/emulsify-starter',
+        },
+      },
+    );
+  });
+
   it('accepts init defaults without prompting when yes is set', async () => {
-    expect.assertions(3);
+    expect.assertions(4);
     getPlatformInfoMock.mockReturnValueOnce(undefined);
 
     await init(progress)(undefined, undefined, {
@@ -193,6 +230,7 @@ describe('init', () => {
     });
 
     expect(inputMock).not.toHaveBeenCalled();
+    expect(selectMock).not.toHaveBeenCalled();
     expect(gitCloneMock).toHaveBeenCalledWith(
       'https://github.com/emulsify-ds/emulsify-starter',
       'emulsifytheme',
@@ -278,14 +316,12 @@ describe('init', () => {
   it('should prompt for all info if name is missing', async () => {
     setStdinIsTTY(true);
     getPlatformInfoMock.mockReturnValueOnce(undefined);
-    inputMock
-      .mockResolvedValueOnce('new-project')
-      .mockResolvedValueOnce(root)
-      .mockResolvedValueOnce('drupal');
+    inputMock.mockResolvedValueOnce('new-project').mockResolvedValueOnce(root);
+    selectMock.mockResolvedValueOnce('drupal');
 
     await init(progress)();
 
-    expect(input).toHaveBeenCalledTimes(3);
+    expect(input).toHaveBeenCalledTimes(2);
     expect(input).toHaveBeenNthCalledWith(1, {
       message: 'Project name:',
       default: 'emulsifyTheme',
@@ -294,8 +330,10 @@ describe('init', () => {
       message: 'Target directory:',
       default: './',
     });
-    expect(input).toHaveBeenNthCalledWith(3, {
+    expect(select).toHaveBeenCalledTimes(1);
+    expect(select).toHaveBeenNthCalledWith(1, {
       message: 'Platform:',
+      choices: ['drupal', 'none'],
       default: 'drupal',
     });
     expect(gitCloneMock).toHaveBeenCalled();

--- a/src/handlers/init.ts
+++ b/src/handlers/init.ts
@@ -131,7 +131,8 @@ export default function init(progress: InstanceType<typeof ProgressBar>) {
     const target = targetParent ? join(targetParent, machineName) : undefined;
 
     const repository = options?.starter || starter?.repository;
-    const checkout = options?.checkout || starter?.checkout;
+    const checkout =
+      options?.checkout || (options?.starter ? undefined : starter?.checkout);
 
     if (!target) {
       throw new CliError(

--- a/src/handlers/init.ts
+++ b/src/handlers/init.ts
@@ -57,6 +57,7 @@ export default function init(progress: InstanceType<typeof ProgressBar>) {
     // Load information about the project and platform.
     const { name: autoPlatformName, emulsifyParentDirectory } =
       (await getPlatformInfo()) || {};
+    const isDetectedDrupalProject = autoPlatformName === 'drupal';
     const canPrompt = process.stdin.isTTY === true;
     const acceptDefaults = options?.yes === true;
 
@@ -210,9 +211,10 @@ export default function init(progress: InstanceType<typeof ProgressBar>) {
       });
 
       log('success', `Created an Emulsify project in ${target}.`);
-      getInitSuccessMessageForPlatform(platformName, target).map(
-        ({ method, message }) => log(method, message),
-      );
+      getInitSuccessMessageForPlatform(platformName, target, {
+        includeDrupalInstallReminder:
+          isDetectedDrupalProject && platformName === 'drupal',
+      }).map(({ method, message }) => log(method, message));
     } catch (e) {
       throw new CliError(`Unable to pull down ${repository}: ${String(e)}`);
     }

--- a/src/handlers/init.ts
+++ b/src/handlers/init.ts
@@ -2,7 +2,7 @@ import { join } from 'path';
 import { existsSync, promises as fs } from 'fs';
 import { simpleGit } from 'simple-git';
 import ProgressBar from 'progress';
-import { input } from '@inquirer/prompts';
+import { input, select } from '@inquirer/prompts';
 
 import type {
   EmulsifyProjectConfiguration,
@@ -29,6 +29,10 @@ const git = simpleGit();
 export const DIRECTORY = 1;
 const DEFAULT_PROJECT_NAME = 'emulsifyTheme';
 const DEFAULT_PLATFORM: Platform = 'drupal';
+const PLATFORM_CHOICES = [
+  'drupal',
+  'none',
+] as const satisfies readonly Platform[];
 
 /**
  * Handler for the initialization command.
@@ -96,10 +100,11 @@ export default function init(progress: InstanceType<typeof ProgressBar>) {
       if (acceptDefaults) {
         platformName = DEFAULT_PLATFORM;
       } else if (canPrompt) {
-        platformName = (await input({
+        platformName = await select({
           message: 'Platform:',
+          choices: PLATFORM_CHOICES,
           default: DEFAULT_PLATFORM,
-        })) as Platform;
+        });
       }
     }
 

--- a/src/handlers/systemInstall.test.ts
+++ b/src/handlers/systemInstall.test.ts
@@ -14,9 +14,11 @@ jest.mock('../util/project/setEmulsifyConfig', () => jest.fn());
 jest.mock('../util/project/getEmulsifyConfig', () => jest.fn());
 jest.mock('../util/fs/findFileInCurrentPath', () => jest.fn());
 jest.mock('../util/fs/executeScript', () => jest.fn());
+jest.mock('@inquirer/prompts');
 
 import fs from 'fs';
 import type { EmulsifySystem } from '@emulsify-cli/config';
+import { select } from '@inquirer/prompts';
 import log from '../lib/log.js';
 import { EMULSIFY_SYSTEM_CONFIG_FILE } from '../lib/constants.js';
 import getAvailableSystems from '../util/system/getAvailableSystems.js';
@@ -47,6 +49,15 @@ const getEmulsifyConfigMock = getEmulsifyConfig as jest.Mock;
 const findFileInCurrentPathMock = findFileInCurrentPath as jest.Mock;
 const executeScriptMock = executeScript as jest.Mock;
 const existsSyncMock = fs.existsSync as jest.Mock;
+const selectMock = select as jest.Mock;
+const originalStdinIsTTY = process.stdin.isTTY;
+
+function setStdinIsTTY(value: boolean | undefined) {
+  Object.defineProperty(process.stdin, 'isTTY', {
+    value,
+    configurable: true,
+  });
+}
 
 const projectConfig = {
   project: {
@@ -93,15 +104,21 @@ const system = {
   variants: [variant],
 } as EmulsifySystem;
 
+const availableSystems = [
+  {
+    name: 'compound',
+    repository: 'https://github.com/emulsify-ds/compound.git',
+  },
+  {
+    name: 'emulsify-ui-kit',
+    repository: 'https://github.com/emulsify-ds/emulsify-ui-kit.git',
+  },
+];
+
 describe('getSystemRepoInfo', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    getAvailableSystemsMock.mockResolvedValue([
-      {
-        name: 'compound',
-        repository: 'https://github.com/emulsify-ds/compound.git',
-      },
-    ]);
+    getAvailableSystemsMock.mockResolvedValue(availableSystems);
   });
 
   it('returns repository information from explicit repository options', async () => {
@@ -141,20 +158,23 @@ describe('getSystemRepoInfo', () => {
       repository: 'https://github.com/emulsify-ds/compound.git',
     });
   });
+
+  it('returns repository information from the emulsify-ui-kit system name', async () => {
+    await expect(getSystemRepoInfo('emulsify-ui-kit', {})).resolves.toEqual({
+      name: 'emulsify-ui-kit',
+      repository: 'https://github.com/emulsify-ds/emulsify-ui-kit.git',
+    });
+  });
 });
 
 describe('systemInstall', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    setStdinIsTTY(false);
     // The handler clones systems through a higher-order cache helper.
     cloneIntoCacheMock.mockReturnValue(cloneSystemMock);
     cloneSystemMock.mockResolvedValue(undefined);
-    getAvailableSystemsMock.mockResolvedValue([
-      {
-        name: 'compound',
-        repository: 'https://github.com/emulsify-ds/compound.git',
-      },
-    ]);
+    getAvailableSystemsMock.mockResolvedValue(availableSystems);
     getCachedItemCheckoutMock.mockResolvedValue('main');
     getRepositoryLatestTagMock.mockResolvedValue('v1.0.0');
     installComponentFromCacheMock.mockResolvedValue(undefined);
@@ -166,6 +186,10 @@ describe('systemInstall', () => {
     findFileInCurrentPathMock.mockReturnValue('/project/system.emulsify.json');
     existsSyncMock.mockReturnValue(true);
     executeScriptMock.mockResolvedValue(undefined);
+  });
+
+  afterAll(() => {
+    setStdinIsTTY(originalStdinIsTTY);
   });
 
   it('throws when no Emulsify project is detected', async () => {
@@ -187,6 +211,84 @@ describe('systemInstall', () => {
 
     await expect(systemInstall('compound', {})).rejects.toThrow(
       'You have already selected a system within this Emulsify project.',
+    );
+  });
+
+  it('prompts with built-in systems plus create and cancel when no system is provided in an interactive terminal', async () => {
+    setStdinIsTTY(true);
+    selectMock.mockResolvedValueOnce('cancel');
+
+    await systemInstall(undefined, {});
+
+    expect(selectMock).toHaveBeenCalledTimes(1);
+    expect(selectMock).toHaveBeenNthCalledWith(1, {
+      message: 'Choose a component system:',
+      choices: ['compound', 'emulsify-ui-kit', 'create a new system', 'cancel'],
+    });
+  });
+
+  it('installs the selected built-in system from the interactive prompt', async () => {
+    setStdinIsTTY(true);
+    selectMock.mockResolvedValueOnce('compound');
+
+    await systemInstall(undefined, {});
+
+    expect(cloneIntoCacheMock).toHaveBeenCalledWith('systems', ['compound']);
+    expect(cloneSystemMock).toHaveBeenCalledWith({
+      repository: 'https://github.com/emulsify-ds/compound.git',
+      checkout: 'v1.0.0',
+    });
+    expect(setEmulsifyConfigMock).toHaveBeenCalledWith({
+      system: {
+        repository: 'https://github.com/emulsify-ds/compound.git',
+        checkout: 'v1.0.0',
+      },
+      variant: {
+        platform: 'drupal',
+        structureImplementations: variant.structureImplementations,
+      },
+    });
+    expect(logMock).toHaveBeenCalledWith(
+      'success',
+      'Successfully installed the compound system using the drupal variant.',
+    );
+  });
+
+  it('cancels the interactive prompt without modifying files', async () => {
+    setStdinIsTTY(true);
+    selectMock.mockResolvedValueOnce('cancel');
+
+    await systemInstall(undefined, {});
+
+    expect(logMock).toHaveBeenCalledWith('info', 'System install cancelled.');
+    expect(cloneIntoCacheMock).not.toHaveBeenCalled();
+    expect(cloneSystemMock).not.toHaveBeenCalled();
+    expect(getJsonFromCachedFileMock).not.toHaveBeenCalled();
+    expect(setEmulsifyConfigMock).not.toHaveBeenCalled();
+    expect(installComponentFromCacheMock).not.toHaveBeenCalled();
+    expect(installGeneralAssetsFromCacheMock).not.toHaveBeenCalled();
+  });
+
+  it('throws a temporary error when create a new system is selected', async () => {
+    setStdinIsTTY(true);
+    selectMock.mockResolvedValueOnce('create a new system');
+
+    await expect(systemInstall(undefined, {})).rejects.toThrow(
+      'Creating a new system is not supported yet.',
+    );
+  });
+
+  it('does not prompt when a system name is provided', async () => {
+    setStdinIsTTY(true);
+
+    await systemInstall('compound', {});
+
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('throws a helpful error in non-interactive mode when no system is provided', async () => {
+    await expect(systemInstall(undefined, {})).rejects.toThrow(
+      'Unable to download specified system. You must either specify a valid name of an out-of-the-box system using the --name flag, or specify a valid repository and branch/tag/commit using the --repository and --checkout flags.',
     );
   });
 
@@ -407,11 +509,14 @@ describe('systemInstall', () => {
   });
 
   it('uses explicit repository options when provided', async () => {
+    setStdinIsTTY(true);
+
     await systemInstall(undefined, {
       repository: 'https://github.com/example/custom-system.git',
       checkout: 'release',
     });
 
+    expect(selectMock).not.toHaveBeenCalled();
     expect(cloneIntoCacheMock).toHaveBeenCalledWith('systems', [
       'custom-system',
     ]);

--- a/src/handlers/systemInstall.test.ts
+++ b/src/handlers/systemInstall.test.ts
@@ -14,6 +14,7 @@ jest.mock('../util/project/setEmulsifyConfig', () => jest.fn());
 jest.mock('../util/project/getEmulsifyConfig', () => jest.fn());
 jest.mock('../util/fs/findFileInCurrentPath', () => jest.fn());
 jest.mock('../util/fs/executeScript', () => jest.fn());
+jest.mock('../util/fs/writeToJsonFile', () => jest.fn());
 jest.mock('@inquirer/prompts');
 
 import fs from 'fs';
@@ -32,6 +33,7 @@ import setEmulsifyConfig from '../util/project/setEmulsifyConfig.js';
 import getEmulsifyConfig from '../util/project/getEmulsifyConfig.js';
 import findFileInCurrentPath from '../util/fs/findFileInCurrentPath.js';
 import executeScript from '../util/fs/executeScript.js';
+import writeToJsonFile from '../util/fs/writeToJsonFile.js';
 import systemInstall, { getSystemRepoInfo } from './systemInstall.js';
 
 const logMock = log as jest.Mock;
@@ -48,6 +50,7 @@ const setEmulsifyConfigMock = setEmulsifyConfig as jest.Mock;
 const getEmulsifyConfigMock = getEmulsifyConfig as jest.Mock;
 const findFileInCurrentPathMock = findFileInCurrentPath as jest.Mock;
 const executeScriptMock = executeScript as jest.Mock;
+const writeToJsonFileMock = writeToJsonFile as jest.Mock;
 const existsSyncMock = fs.existsSync as jest.Mock;
 const selectMock = select as jest.Mock;
 const originalStdinIsTTY = process.stdin.isTTY;
@@ -114,6 +117,32 @@ const availableSystems = [
     repository: 'https://github.com/emulsify-ds/emulsify-ui-kit.git',
   },
 ];
+
+function customSystemDefinition(platform: 'drupal' | 'none'): EmulsifySystem {
+  return {
+    name: 'custom-system',
+    homepage: 'https://example.com/custom-system',
+    repository: 'https://github.com/example/custom-system.git',
+    structure: [
+      {
+        name: 'components',
+        description: 'Project component library',
+      },
+    ],
+    variants: [
+      {
+        platform,
+        structureImplementations: [
+          {
+            name: 'components',
+            directory: './src/components',
+          },
+        ],
+        components: [],
+      },
+    ],
+  };
+}
 
 describe('getSystemRepoInfo', () => {
   beforeEach(() => {
@@ -182,6 +211,7 @@ describe('systemInstall', () => {
     getJsonFromCachedFileMock.mockResolvedValue(system);
     setEmulsifyConfigMock.mockResolvedValue(undefined);
     getEmulsifyConfigMock.mockResolvedValue(projectConfig);
+    writeToJsonFileMock.mockResolvedValue(undefined);
     // A found system config plus an existing hook covers the optional hook branch.
     findFileInCurrentPathMock.mockReturnValue('/project/system.emulsify.json');
     existsSyncMock.mockReturnValue(true);
@@ -269,13 +299,85 @@ describe('systemInstall', () => {
     expect(installGeneralAssetsFromCacheMock).not.toHaveBeenCalled();
   });
 
-  it('throws a temporary error when create a new system is selected', async () => {
+  it('writes a custom system definition when create a new system is selected', async () => {
     setStdinIsTTY(true);
     selectMock.mockResolvedValueOnce('create a new system');
+    findFileInCurrentPathMock.mockReturnValueOnce(
+      '/project/project.emulsify.json',
+    );
+    existsSyncMock.mockReturnValueOnce(false);
+
+    await systemInstall(undefined, {});
+
+    expect(writeToJsonFileMock).toHaveBeenCalledWith(
+      '/project/system.emulsify.json',
+      customSystemDefinition('drupal'),
+    );
+    expect(logMock).toHaveBeenCalledWith(
+      'success',
+      'Created system.emulsify.json.',
+    );
+    expect(logMock).toHaveBeenCalledWith(
+      'info',
+      'Add your real system name, repository, structures, variants, and components before using this system to install or generate components.',
+    );
+  });
+
+  it('uses the current none platform in the custom system definition', async () => {
+    setStdinIsTTY(true);
+    selectMock.mockResolvedValueOnce('create a new system');
+    getEmulsifyConfigMock.mockResolvedValueOnce({
+      ...projectConfig,
+      project: {
+        ...projectConfig.project,
+        platform: 'none',
+      },
+    });
+    findFileInCurrentPathMock.mockReturnValueOnce(
+      '/project/project.emulsify.json',
+    );
+    existsSyncMock.mockReturnValueOnce(false);
+
+    await systemInstall(undefined, {});
+
+    expect(writeToJsonFileMock).toHaveBeenCalledWith(
+      '/project/system.emulsify.json',
+      customSystemDefinition('none'),
+    );
+  });
+
+  it('does not overwrite an existing custom system definition', async () => {
+    setStdinIsTTY(true);
+    selectMock.mockResolvedValueOnce('create a new system');
+    findFileInCurrentPathMock.mockReturnValueOnce(
+      '/project/project.emulsify.json',
+    );
+    existsSyncMock.mockReturnValueOnce(true);
 
     await expect(systemInstall(undefined, {})).rejects.toThrow(
-      'Creating a new system is not supported yet.',
+      'system.emulsify.json already exists. Remove or rename it before creating a new custom system definition.',
     );
+
+    expect(writeToJsonFileMock).not.toHaveBeenCalled();
+  });
+
+  it('does not run remote install side effects when creating a custom system definition', async () => {
+    setStdinIsTTY(true);
+    selectMock.mockResolvedValueOnce('create a new system');
+    findFileInCurrentPathMock.mockReturnValueOnce(
+      '/project/project.emulsify.json',
+    );
+    existsSyncMock.mockReturnValueOnce(false);
+
+    await systemInstall(undefined, {});
+
+    expect(cloneIntoCacheMock).not.toHaveBeenCalled();
+    expect(cloneSystemMock).not.toHaveBeenCalled();
+    expect(getJsonFromCachedFileMock).not.toHaveBeenCalled();
+    expect(setEmulsifyConfigMock).not.toHaveBeenCalled();
+    expect(installComponentFromCacheMock).not.toHaveBeenCalled();
+    expect(installGeneralAssetsFromCacheMock).not.toHaveBeenCalled();
+    expect(executeScriptMock).not.toHaveBeenCalled();
   });
 
   it('does not prompt when a system name is provided', async () => {

--- a/src/handlers/systemInstall.ts
+++ b/src/handlers/systemInstall.ts
@@ -1,13 +1,18 @@
 import type { InstallSystemHandlerOptions } from '@emulsify-cli/handlers';
 import type { GitCloneOptions } from '@emulsify-cli/git';
-import type { EmulsifySystem } from '@emulsify-cli/config';
+import type {
+  EmulsifyProjectConfiguration,
+  EmulsifySystem,
+  Platform,
+} from '@emulsify-cli/config';
 
 import { Ajv } from 'ajv';
 import addFormats from 'ajv-formats';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { existsSync } from 'fs';
 import { select } from '@inquirer/prompts';
 import {
+  EMULSIFY_PROJECT_CONFIG_FILE,
   EMULSIFY_SYSTEM_CONFIG_FILE,
   EMULSIFY_PROJECT_HOOK_FOLDER,
   EMULSIFY_PROJECT_HOOK_SYSTEM_INSTALL,
@@ -26,6 +31,7 @@ import setEmulsifyConfig from '../util/project/setEmulsifyConfig.js';
 import getEmulsifyConfig from '../util/project/getEmulsifyConfig.js';
 import findFileInCurrentPath from '../util/fs/findFileInCurrentPath.js';
 import executeScript from '../util/fs/executeScript.js';
+import writeToJsonFile from '../util/fs/writeToJsonFile.js';
 
 const CREATE_NEW_SYSTEM_CHOICE = 'create a new system';
 const CANCEL_SYSTEM_INSTALL_CHOICE = 'cancel';
@@ -106,11 +112,71 @@ async function promptForSystemInstallChoice(): Promise<string | void> {
     return;
   }
 
-  if (selectedSystem === CREATE_NEW_SYSTEM_CHOICE) {
-    throw new CliError('Creating a new system is not supported yet.');
+  return selectedSystem;
+}
+
+function getCustomSystemPlatform(platform: string): Platform {
+  return platform === 'drupal' || platform === 'none' ? platform : 'none';
+}
+
+function buildCustomSystemDefinition(platform: Platform): EmulsifySystem {
+  return {
+    name: 'custom-system',
+    homepage: 'https://example.com/custom-system',
+    repository: 'https://github.com/example/custom-system.git',
+    structure: [
+      {
+        name: 'components',
+        description: 'Project component library',
+      },
+    ],
+    variants: [
+      {
+        platform,
+        structureImplementations: [
+          {
+            name: 'components',
+            directory: './src/components',
+          },
+        ],
+        components: [],
+      },
+    ],
+  };
+}
+
+async function scaffoldCustomSystemDefinition(
+  projectConfig: EmulsifyProjectConfiguration,
+): Promise<void> {
+  const projectConfigPath = findFileInCurrentPath(EMULSIFY_PROJECT_CONFIG_FILE);
+  if (!projectConfigPath) {
+    throw new CliError(
+      `Unable to find ${EMULSIFY_PROJECT_CONFIG_FILE}. Run this command from within an Emulsify project.`,
+    );
   }
 
-  return selectedSystem;
+  const systemConfigPath = join(
+    dirname(projectConfigPath),
+    EMULSIFY_SYSTEM_CONFIG_FILE,
+  );
+  if (existsSync(systemConfigPath)) {
+    throw new CliError(
+      `${EMULSIFY_SYSTEM_CONFIG_FILE} already exists. Remove or rename it before creating a new custom system definition.`,
+    );
+  }
+
+  await writeToJsonFile<EmulsifySystem>(
+    systemConfigPath,
+    buildCustomSystemDefinition(
+      getCustomSystemPlatform(projectConfig.project.platform),
+    ),
+  );
+
+  log('success', `Created ${EMULSIFY_SYSTEM_CONFIG_FILE}.`);
+  log(
+    'info',
+    'Add your real system name, repository, structures, variants, and components before using this system to install or generate components.',
+  );
 }
 
 /**
@@ -147,6 +213,11 @@ export default async function systemInstall(
   if (!selectedName && !options.repository && process.stdin.isTTY === true) {
     selectedName = await promptForSystemInstallChoice();
     if (!selectedName) {
+      return;
+    }
+
+    if (selectedName === CREATE_NEW_SYSTEM_CHOICE) {
+      await scaffoldCustomSystemDefinition(projectConfig);
       return;
     }
   }

--- a/src/handlers/systemInstall.ts
+++ b/src/handlers/systemInstall.ts
@@ -6,6 +6,7 @@ import { Ajv } from 'ajv';
 import addFormats from 'ajv-formats';
 import { join } from 'path';
 import { existsSync } from 'fs';
+import { select } from '@inquirer/prompts';
 import {
   EMULSIFY_SYSTEM_CONFIG_FILE,
   EMULSIFY_PROJECT_HOOK_FOLDER,
@@ -25,6 +26,11 @@ import setEmulsifyConfig from '../util/project/setEmulsifyConfig.js';
 import getEmulsifyConfig from '../util/project/getEmulsifyConfig.js';
 import findFileInCurrentPath from '../util/fs/findFileInCurrentPath.js';
 import executeScript from '../util/fs/executeScript.js';
+
+const CREATE_NEW_SYSTEM_CHOICE = 'create a new system';
+const CANCEL_SYSTEM_INSTALL_CHOICE = 'cancel';
+const SYSTEM_INSTALL_ERROR =
+  'Unable to download specified system. You must either specify a valid name of an out-of-the-box system using the --name flag, or specify a valid repository and branch/tag/commit using the --repository and --checkout flags.';
 
 async function loadSchemas() {
   const [{ default: systemSchema }, { default: variantSchema }] =
@@ -84,6 +90,29 @@ export async function getSystemRepoInfo(
   }
 }
 
+async function promptForSystemInstallChoice(): Promise<string | void> {
+  const availableSystems = await getAvailableSystems();
+  const selectedSystem = await select({
+    message: 'Choose a component system:',
+    choices: [
+      ...availableSystems.map(({ name }) => name),
+      CREATE_NEW_SYSTEM_CHOICE,
+      CANCEL_SYSTEM_INSTALL_CHOICE,
+    ],
+  });
+
+  if (selectedSystem === CANCEL_SYSTEM_INSTALL_CHOICE) {
+    log('info', 'System install cancelled.');
+    return;
+  }
+
+  if (selectedSystem === CREATE_NEW_SYSTEM_CHOICE) {
+    throw new CliError('Creating a new system is not supported yet.');
+  }
+
+  return selectedSystem;
+}
+
 /**
  * Handler for the `system install` command.
  *
@@ -114,11 +143,17 @@ export default async function systemInstall(
 
   // Attempt to load system information, and exit with a log message
   // if a valid system was not found.
-  const repo = await getSystemRepoInfo(name, options);
+  let selectedName = name;
+  if (!selectedName && !options.repository && process.stdin.isTTY === true) {
+    selectedName = await promptForSystemInstallChoice();
+    if (!selectedName) {
+      return;
+    }
+  }
+
+  const repo = await getSystemRepoInfo(selectedName, options);
   if (!repo) {
-    throw new CliError(
-      'Unable to download specified system. You must either specify a valid name of an out-of-the-box system using the --name flag, or specify a valid repository and branch/tag/commit using the --repository and --checkout flags.',
-    );
+    throw new CliError(SYSTEM_INSTALL_ERROR);
   }
 
   // Attempt to get latest tag if no branch was supplied.

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,82 @@ import boxen from 'boxen';
 
 const packageInfo = createRequire(import.meta.url)('../package.json');
 
+function getRootHelp(): string {
+  return [
+    `${packageInfo.productName} ${packageInfo.version}`,
+    '',
+    'Create Emulsify projects, choose component systems, install components, and generate local components.',
+    '',
+    'Usage:',
+    '  emulsify',
+    '  emulsify --help',
+    '  emulsify <command> --help',
+    '  emulsify init [name] [path] [options]',
+    '  emulsify system install [name] [options]',
+    '  emulsify component <command> [options]',
+    '',
+    'Common workflow:',
+    '  emulsify init',
+    '  emulsify system install',
+    '  emulsify component list',
+    '  emulsify component install <name>',
+    '  emulsify component create <name>',
+    '',
+    'Commands:',
+    '  init [name] [path]',
+    '    Create a project from a starter repository. Prompts for project name, target directory,',
+    '    and platform when values are missing in an interactive terminal.',
+    '    Options:',
+    '      -m, --machineName <machineName>     Set the project folder/config machine name.',
+    '      -s, --starter <repository>          Use a custom starter repository.',
+    '      -c, --checkout <commit/branch/tag>  Checkout for the starter repository.',
+    '      -p, --platform <drupal|none>        Select the project platform when auto-detection is unavailable.',
+    '      -y, --yes                           Accept defaults for missing init values without prompting.',
+    '',
+    '  system list',
+    '    List built-in component systems available for installation. Alias: system ls.',
+    '',
+    '  system install [name]',
+    '    Install a built-in or repository-backed component system. With no name or repository in',
+    '    an interactive terminal, prompts for compound, emulsify-ui-kit, create a new system,',
+    '    or cancel.',
+    '    Options:',
+    '      -r, --repository <repository>       Install from a custom system repository ending in .git.',
+    '      -c, --checkout <commit/branch/tag>  Checkout to use with --repository.',
+    '      -a, --all                           Install every component in the selected variant.',
+    '',
+    '  component list',
+    '    List components available from the installed system and selected variant. Alias: component ls.',
+    '',
+    '  component install [name]',
+    '    Install one component, dependencies, or all components from the installed system. Alias: component i.',
+    '    Options:',
+    '      -f, --force                         Replace an existing component destination.',
+    '      -a, --all                           Install all available components.',
+    '          --dry-run                       Preview installs without writing files.',
+    '',
+    '  component create [name]',
+    '    Generate a new local component in this project. Alias: component c.',
+    '    Options:',
+    '      -d, --directory <directory>         Variant structure where the component should be created.',
+    '      -f, --format <default|sdc>          Component format to generate.',
+    '      -y, --yes                           Replace existing generated components without prompting.',
+    '          --dry-run                       Preview generated files without writing them.',
+    '',
+    '  help [command]',
+    '    Show help for a command.',
+    '',
+    'Global options:',
+    '  -c, --checkout <commit/branch/tag>      Shared checkout option for commands that clone repositories.',
+    '  -V, --version                           Show the installed CLI version.',
+    '  -h, --help                              Show this help output.',
+    '',
+  ].join('\n');
+}
+
 // Main program commands.
 program
+  .name('emulsify')
   .enablePositionalOptions()
   .option(
     '-c --checkout <commit/branch/tag>',
@@ -24,25 +98,20 @@ program
   );
 
 program
-  .command('init [name] [path]', {
-    isDefault: true,
-  })
-  .description('Initialize an Emulsify project')
+  .command('init [name] [path]')
+  .description('Create a new Emulsify project from a starter repository')
   .option(
     '-m --machineName <machineName>',
-    'Machine-friendly name of the project you are initializing. If not provided, this will be automatically generated.',
+    'Machine-friendly project folder and config name. If omitted, this is generated from the project name.',
   )
-  .option(
-    '-s --starter <repository>',
-    'Git repository of the Emulsify starter you would like to use, such as the Emulsify Drupal theme: https://github.com/emulsify-ds/emulsify-starter',
-  )
+  .option('-s --starter <repository>', 'Starter Git repository to clone.')
   .option(
     '-c --checkout <commit/branch/tag>',
-    'Commit, branch or tag of the base repository that should be checked out',
+    'Starter commit, branch, or tag to check out after clone.',
   )
   .option(
-    '-p --platform <drupal/wordpress/etc>',
-    'Name of the platform Emulsify is being within. In some cases, Emulsify is able to automatically detect this. If it is not, Emulsify will prompt you to specify.',
+    '-p --platform <drupal|none>',
+    'Project platform to use when auto-detection is unavailable or should be overridden.',
   )
   .option(
     '-y --yes',
@@ -53,60 +122,49 @@ program
 // System sub-commands.
 const system = program
   .command('system')
-  .description(
-    'Parent command that contains sub-commands pertaining to systems',
-  );
+  .description('List, install, or scaffold component systems');
 system
   .command('list')
-  .description(
-    'Lists all of the available systems that Emulsify supports out-of-the-box',
-  )
+  .description('List built-in systems available for installation')
   .alias('ls')
   .action(systemList);
 system
   .command('install [name]')
   .description(
-    'Install a system within an Emulsify project. You must specify either the name of an out-of-the-box system (such as compound), or a link to a git repository containing the system you want to install',
+    'Install a component system, prompt for a system, or scaffold a local system definition',
   )
   .option(
     '-r --repository <repository>',
-    'Git repository containing the system you would like to install',
+    'Git repository containing the system to install. Custom repository URLs must end in .git.',
   )
   .option(
     '-c --checkout <commit/branch/tag>',
-    'Commit, branch or tag of the base repository that should be checked out. MUST be provided if you are passing along a repository (-r or --repository). Tags or commit hashes are strongly preferable, because you want to ensure that you are using the same version of the system every time you install components, etc',
+    'Commit, branch, or tag to check out. Required when --repository is used.',
   )
   .option(
     '-a --all',
-    'Use this to install all available components within the specified system. Without this flag, only the required system components will be installed.',
+    'Install every component in the selected variant. Without this flag, only required components are installed.',
   )
   .action(systemInstall);
 
 // Component sub-commands.
 const component = program
   .command('component')
-  .description(
-    'Parent command that contains sub-commands pertaining to components',
-  );
+  .description('List, install, or create components');
 component
   .command('list')
   .description(
-    'Lists all of the components that are available for installation within your project based on the system and variant you selected',
+    'List components available from the installed system and variant',
   )
   .alias('ls')
   .action(componentList);
 component
   .command('install [name]')
-  .description(
-    "Install a component from within the current project's system and variant",
-  )
-  .option(
-    '-f --force',
-    'Use this to overwrite a component that is already installed',
-  )
+  .description('Install one component from the installed system and variant')
+  .option('-f --force', 'Replace an existing component destination.')
   .option(
     '-a --all',
-    'Use this to install all available components, rather than specifying a single component to install',
+    'Install all available components instead of one named component.',
   )
   .option(
     '--dry-run',
@@ -118,7 +176,7 @@ component
   .command('create [name]')
   .option(
     '-d --directory <directory>',
-    'Used to set the directory where the new component is to be created',
+    'Variant structure name where the component should be created.',
   )
   .option(
     '-f --format <format>',
@@ -133,9 +191,7 @@ component
     'Preview generated component files without writing or removing files.',
   )
   .alias('c')
-  .description(
-    "Create a component from within the current project's system and variant",
-  )
+  .description('Generate a new local component in the current project')
   .action(componentCreate);
 
 /*
@@ -161,11 +217,21 @@ const boxedMessage = boxen(message, {
 });
 
 program.version(boxedMessage);
+const rootHelpRequested =
+  process.argv.length <= 2 ||
+  (process.argv.length === 3 &&
+    ['--help', '-h', 'help'].includes(process.argv[2]));
+
+if (rootHelpRequested) {
+  process.stdout.write(getRootHelp());
+  process.exit(0);
+}
+
 try {
   await program.parseAsync(process.argv);
 } catch (err) {
   // Expected CliError failures map their message and exitCode to the process;
-  // unexpected failures still produce a message and a generic non-zero exit.
+  // unexpected failures still produce a message and a default non-zero exit.
   if (err instanceof CliError) {
     log('error', err.message);
     process.exitCode = err.exitCode;

--- a/src/util/platform/getInitSuccessMessageForPlatform.test.ts
+++ b/src/util/platform/getInitSuccessMessageForPlatform.test.ts
@@ -1,6 +1,5 @@
 import getInitSuccessMessageForPlatform from './getInitSuccessMessageForPlatform.js';
 
-const egg = ['  __', ' /  \\', ' \\__/'].join('\n');
 const systemSelectionMessage = [
   'Next, choose a component system:',
   '  emulsify system install',
@@ -15,10 +14,6 @@ describe('getInitSuccessMessageForPlatform', () => {
   it('returns compact Drupal integration and system selection guidance', () => {
     expect.assertions(1);
     expect(getInitSuccessMessageForPlatform('drupal', '/directory')).toEqual([
-      {
-        method: 'verbose',
-        message: egg,
-      },
       {
         method: 'info',
         message: drupalIntegrationMessage,
@@ -48,10 +43,6 @@ describe('getInitSuccessMessageForPlatform', () => {
     const messages = result.map(({ message }) => message).join('\n');
 
     expect(result).toEqual([
-      {
-        method: 'verbose',
-        message: egg,
-      },
       {
         method: 'info',
         message: systemSelectionMessage,

--- a/src/util/platform/getInitSuccessMessageForPlatform.test.ts
+++ b/src/util/platform/getInitSuccessMessageForPlatform.test.ts
@@ -1,26 +1,78 @@
 import getInitSuccessMessageForPlatform from './getInitSuccessMessageForPlatform.js';
 
+const egg = ['  __', ' /  \\', ' \\__/'].join('\n');
+const systemSelectionMessage = [
+  'Next, choose a component system:',
+  '  emulsify system install',
+].join('\n');
+const drupalIntegrationMessage = [
+  'Install the Drupal integration module:',
+  '  composer require drupal/emulsify_tools',
+  '  drush en emulsify_tools -y',
+].join('\n');
+
 describe('getInitSuccessMessageForPlatform', () => {
-  it('can return init success log messages for a given platform', () => {
+  it('returns compact Drupal integration and system selection guidance', () => {
     expect.assertions(1);
     expect(getInitSuccessMessageForPlatform('drupal', '/directory')).toEqual([
       {
-        method: 'info',
-        message: expect.any(String),
-      },
-      {
         method: 'verbose',
-        message: expect.any(String),
+        message: egg,
       },
       {
         method: 'info',
-        message: expect.any(String),
+        message: drupalIntegrationMessage,
       },
       {
-        method: 'verbose',
-        message: expect.any(String),
+        method: 'info',
+        message: systemSelectionMessage,
       },
     ]);
+  });
+
+  it('does not mention old Drupal module requirements', () => {
+    expect.assertions(4);
+    const messages = getInitSuccessMessageForPlatform('drupal', '/directory')
+      .map(({ message }) => message)
+      .join('\n');
+
+    expect(messages).not.toContain('drupal/components');
+    expect(messages).not.toContain('drupal/emulsify_twig');
+    expect(messages).not.toContain('components emulsify_twig');
+    expect(messages).not.toContain('emulsify_twig');
+  });
+
+  it('returns system selection guidance without Drupal module reminders for none', () => {
+    expect.assertions(5);
+    const result = getInitSuccessMessageForPlatform('none', '/directory');
+    const messages = result.map(({ message }) => message).join('\n');
+
+    expect(result).toEqual([
+      {
+        method: 'verbose',
+        message: egg,
+      },
+      {
+        method: 'info',
+        message: systemSelectionMessage,
+      },
+    ]);
+    expect(messages).not.toContain('Drupal integration module');
+    expect(messages).not.toContain('composer require drupal/');
+    expect(messages).not.toContain('drush en');
+    expect(messages).not.toContain('emulsify_tools');
+  });
+
+  it('keeps multiline output dense', () => {
+    expect.assertions(1);
+    const messages = getInitSuccessMessageForPlatform(
+      'drupal',
+      '/directory',
+    ).map(({ message }) => message);
+
+    expect(messages).toEqual(
+      messages.map((message) => message.replace(/^\n+|\n+$/g, '')),
+    );
   });
 
   it('returns an empty array if the given platform does not correspond with any success messages', () => {

--- a/src/util/platform/getInitSuccessMessageForPlatform.test.ts
+++ b/src/util/platform/getInitSuccessMessageForPlatform.test.ts
@@ -5,17 +5,25 @@ const systemSelectionMessage = [
   '  emulsify system install',
 ].join('\n');
 const drupalIntegrationMessage = [
-  'Install the Drupal integration module:',
-  '  composer require drupal/emulsify_tools',
+  'Detected a Drupal project.',
+  '',
+  'Install the required Drupal packages with Composer:',
+  '  composer require drupal/emulsify drupal/emulsify_tools',
   '  drush en emulsify_tools -y',
+  '',
+  'The generated Drupal starter uses drupal/emulsify as its base theme and emulsify_tools for Drupal integration, so both packages must exist in the Drupal codebase.',
 ].join('\n');
 
 describe('getInitSuccessMessageForPlatform', () => {
-  it('returns compact Drupal integration and system selection guidance', () => {
+  it('returns compact Drupal integration and system selection guidance for detected Drupal projects', () => {
     expect.assertions(1);
-    expect(getInitSuccessMessageForPlatform('drupal', '/directory')).toEqual([
+    expect(
+      getInitSuccessMessageForPlatform('drupal', '/directory', {
+        includeDrupalInstallReminder: true,
+      }),
+    ).toEqual([
       {
-        method: 'info',
+        method: 'warn',
         message: drupalIntegrationMessage,
       },
       {
@@ -25,9 +33,27 @@ describe('getInitSuccessMessageForPlatform', () => {
     ]);
   });
 
+  it('returns system selection guidance without Drupal install reminders for manually selected Drupal projects', () => {
+    expect.assertions(4);
+    const result = getInitSuccessMessageForPlatform('drupal', '/directory');
+    const messages = result.map(({ message }) => message).join('\n');
+
+    expect(result).toEqual([
+      {
+        method: 'info',
+        message: systemSelectionMessage,
+      },
+    ]);
+    expect(messages).not.toContain('composer require drupal/');
+    expect(messages).not.toContain('emulsify_tools');
+    expect(messages).not.toContain('drupal/emulsify');
+  });
+
   it('does not mention old Drupal module requirements', () => {
     expect.assertions(4);
-    const messages = getInitSuccessMessageForPlatform('drupal', '/directory')
+    const messages = getInitSuccessMessageForPlatform('drupal', '/directory', {
+      includeDrupalInstallReminder: true,
+    })
       .map(({ message }) => message)
       .join('\n');
 
@@ -56,10 +82,9 @@ describe('getInitSuccessMessageForPlatform', () => {
 
   it('keeps multiline output dense', () => {
     expect.assertions(1);
-    const messages = getInitSuccessMessageForPlatform(
-      'drupal',
-      '/directory',
-    ).map(({ message }) => message);
+    const messages = getInitSuccessMessageForPlatform('drupal', '/directory', {
+      includeDrupalInstallReminder: true,
+    }).map(({ message }) => message);
 
     expect(messages).toEqual(
       messages.map((message) => message.replace(/^\n+|\n+$/g, '')),

--- a/src/util/platform/getInitSuccessMessageForPlatform.ts
+++ b/src/util/platform/getInitSuccessMessageForPlatform.ts
@@ -1,5 +1,17 @@
 import { LogMethod } from 'src/lib/log.js';
-import { cyan } from 'colorette';
+
+const EGG = ['  __', ' /  \\', ' \\__/'].join('\n');
+
+const DRUPAL_INTEGRATION_MESSAGE = [
+  'Install the Drupal integration module:',
+  '  composer require drupal/emulsify_tools',
+  '  drush en emulsify_tools -y',
+].join('\n');
+
+const SYSTEM_SELECTION_MESSAGE = [
+  'Next, choose a component system:',
+  '  emulsify system install',
+].join('\n');
 
 /**
  * Returns the init success log messages for a given platform.
@@ -9,42 +21,37 @@ import { cyan } from 'colorette';
  */
 export default function getInitSuccessMessageForPlatform(
   platform: string,
-  directory: string,
+  _directory: string,
 ): {
   method: LogMethod;
   message: string;
 }[] {
-  if (platform === 'none' || platform === 'drupal') {
+  if (platform === 'drupal') {
     return [
       {
-        method: 'info',
-        message:
-          'Make sure you install the modules your Emulsify-based theme requires in order to function.',
-      },
-      {
         method: 'verbose',
-        message: `
-            - composer require drupal/components
-            - composer require drupal/emulsify_twig
-            - drush en components emulsify_twig -y
-            `,
+        message: EGG,
       },
       {
         method: 'info',
-        message: `Once the requirements have been installed, you will need to select a component system to use, as Emulsify does not come with components by default. To do this, navigate to your theme directory (${directory}), and choose a command below.`,
+        message: DRUPAL_INTEGRATION_MESSAGE,
       },
       {
+        method: 'info',
+        message: SYSTEM_SELECTION_MESSAGE,
+      },
+    ];
+  }
+
+  if (platform === 'none') {
+    return [
+      {
         method: 'verbose',
-        message: `
-            ${cyan('List systems')}: emulsify system list
-            ${cyan('Install a system')}: emulsify system install "system-name"
-            ${cyan(
-              'Install default system with default components',
-            )}: emulsify system install compound
-            ${cyan(
-              'Install default system with all components',
-            )}: emulsify system install compound --all
-            `,
+        message: EGG,
+      },
+      {
+        method: 'info',
+        message: SYSTEM_SELECTION_MESSAGE,
       },
     ];
   }

--- a/src/util/platform/getInitSuccessMessageForPlatform.ts
+++ b/src/util/platform/getInitSuccessMessageForPlatform.ts
@@ -1,7 +1,5 @@
 import { LogMethod } from 'src/lib/log.js';
 
-const EGG = ['  __', ' /  \\', ' \\__/'].join('\n');
-
 const DRUPAL_INTEGRATION_MESSAGE = [
   'Install the Drupal integration module:',
   '  composer require drupal/emulsify_tools',
@@ -29,10 +27,6 @@ export default function getInitSuccessMessageForPlatform(
   if (platform === 'drupal') {
     return [
       {
-        method: 'verbose',
-        message: EGG,
-      },
-      {
         method: 'info',
         message: DRUPAL_INTEGRATION_MESSAGE,
       },
@@ -45,10 +39,6 @@ export default function getInitSuccessMessageForPlatform(
 
   if (platform === 'none') {
     return [
-      {
-        method: 'verbose',
-        message: EGG,
-      },
       {
         method: 'info',
         message: SYSTEM_SELECTION_MESSAGE,

--- a/src/util/platform/getInitSuccessMessageForPlatform.ts
+++ b/src/util/platform/getInitSuccessMessageForPlatform.ts
@@ -1,9 +1,13 @@
 import { LogMethod } from 'src/lib/log.js';
 
 const DRUPAL_INTEGRATION_MESSAGE = [
-  'Install the Drupal integration module:',
-  '  composer require drupal/emulsify_tools',
+  'Detected a Drupal project.',
+  '',
+  'Install the required Drupal packages with Composer:',
+  '  composer require drupal/emulsify drupal/emulsify_tools',
   '  drush en emulsify_tools -y',
+  '',
+  'The generated Drupal starter uses drupal/emulsify as its base theme and emulsify_tools for Drupal integration, so both packages must exist in the Drupal codebase.',
 ].join('\n');
 
 const SYSTEM_SELECTION_MESSAGE = [
@@ -11,30 +15,44 @@ const SYSTEM_SELECTION_MESSAGE = [
   '  emulsify system install',
 ].join('\n');
 
+type InitSuccessMessageOptions = {
+  includeDrupalInstallReminder?: boolean;
+};
+
 /**
  * Returns the init success log messages for a given platform.
  *
  * @param platform name of platform.
+ * @param options.includeDrupalInstallReminder whether to include Composer package guidance for an auto-detected Drupal project.
  * @returns array containing objects with a log method, and message.
  */
 export default function getInitSuccessMessageForPlatform(
   platform: string,
   _directory: string,
+  options: InitSuccessMessageOptions = {},
 ): {
   method: LogMethod;
   message: string;
 }[] {
   if (platform === 'drupal') {
-    return [
-      {
-        method: 'info',
+    const messages: {
+      method: LogMethod;
+      message: string;
+    }[] = [];
+
+    if (options.includeDrupalInstallReminder) {
+      messages.push({
+        method: 'warn',
         message: DRUPAL_INTEGRATION_MESSAGE,
-      },
-      {
-        method: 'info',
-        message: SYSTEM_SELECTION_MESSAGE,
-      },
-    ];
+      });
+    }
+
+    messages.push({
+      method: 'info',
+      message: SYSTEM_SELECTION_MESSAGE,
+    });
+
+    return messages;
   }
 
   if (platform === 'none') {


### PR DESCRIPTION
## Summary

Prepares the Emulsify CLI v2.2.0 release by promoting the completed `develop` changes to `main`.

## Highlights

- Adds a dedicated root help screen for `emulsify` and `emulsify --help`.
- Changes a bare `emulsify` invocation to display help instead of starting project initialization.
- Improves interactive project initialization with a platform selector for `drupal` and `none`.
- Adds an interactive `emulsify system install` workflow that can:
  - Install a built-in component system.
  - Scaffold a local `system.emulsify.json`.
  - Cancel without modifying the project.
- Prevents custom system scaffolding from overwriting an existing `system.emulsify.json`.
- Uses the current project platform when scaffolding a custom system definition.
- Adds concise post-initialization guidance for selecting a component system.
- Shows Drupal Composer package guidance only when initialization detects an existing Drupal project.
- Updates the Drupal guidance to include both `drupal/emulsify` and `drupal/emulsify_tools`.
- Fixes custom starter initialization so it does not inherit the checkout configured for a built-in starter.
- Improves command descriptions and option help throughout the CLI.
- Expands automated coverage for interactive prompts, system scaffolding, root help, and initialization output.
- Updates the package version to `2.2.0`.

## Notable behavior change

Running `emulsify` without a command now displays the root help output. Use `emulsify init` to begin project initialization.

## Documentation update

This release updates:

- `README.md`
- `docs/cli-reference.md`
- `docs/project-initialization.md`
- `docs/systems.md`

The documentation covers the root help output, platform selection, interactive system installation, custom system scaffolding, Drupal package guidance, and non-interactive workflows.

## How to review this pull request

- [ ] Run `npm ci`.
- [ ] Run `npm run build`.
- [ ] Run `npm run type`.
- [ ] Run `npm test`.
- [ ] Run `npm pack --dry-run`.
- [ ] Run `emulsify` and confirm that the root help screen is displayed.
- [ ] Run `emulsify init` interactively and confirm that `drupal` and `none` are presented as platform choices when detection is unavailable.
- [ ] Initialize inside a detected Drupal project and confirm that the required Composer package guidance is displayed.
- [ ] Initialize outside a detected Drupal project and confirm that the Drupal-specific package reminder is omitted.
- [ ] Run `emulsify system install` without a system name and verify the install, scaffold, and cancel choices.
- [ ] Confirm that creating a custom system writes `system.emulsify.json` without running remote installation steps.
- [ ] Confirm that an existing `system.emulsify.json` is not overwritten.
- [ ] Confirm that explicit system names and repository options remain non-interactive.
- [ ] Confirm that a custom starter without `--checkout` does not use a built-in starter checkout.

## Related PR

- #341

## Release behavior

Merging this PR into `main` should trigger the automated publish workflow for Emulsify CLI v2.2.0.

## Closing issues

N/A